### PR TITLE
Add vendor folder and composer.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR ensures that the vendor folder and the composer.lock are ignored from any commit.

## Test Plan

Nothing to test here

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I did.
Unfortunately the guideline is deprecated, and some commands are missing (e.g. `format`, `lint`, etc...)