### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Appwrite/Client.php
+++ b/src/Appwrite/Client.php
@@ -382,7 +382,6 @@ class Client
             throw new AppwriteException(curl_error($ch), $responseStatus, $responseBody['type'] ?? '', $responseBody);
         }
         
-        curl_close($ch);
 
         if($responseStatus >= 400) {
             if(is_array($responseBody)) {


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
