### PR TITLE
feat: PHP SDK update for version 23.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 23.1.1
 
 * Fixed: `Database` model `policies` and `archives` now hydrate as `BackupPolicy` / `BackupArchive` instead of `Index` / `Collection`
+* Added: `prompt` parameter to `Project::updateOAuth2Google` and `prompt` field on the `OAuth2Google` model, backed by the new `OAuth2GooglePrompt` enum
+* Added: `Project::updateDenyCanonicalEmailPolicy`, `Project::updateDenyDisposableEmailPolicy`, and `Project::updateDenyFreeEmailPolicy`
+* Updated: `BuildRuntime` and `Runtime` enums with `deno-1.21`, `deno-1.24`, and `deno-1.35`
 
 ## 23.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 23.1.1
+
+* Fixed: `Database` model `policies` and `archives` now hydrate as `BackupPolicy` / `BackupArchive` instead of `Index` / `Collection`
+
 ## 23.1.0
 
 * Added: Introduced `bigint` create/update APIs for legacy Databases attributes

--- a/docs/examples/project/update-deny-canonical-email-policy.md
+++ b/docs/examples/project/update-deny-canonical-email-policy.md
@@ -3,7 +3,6 @@
 
 use Appwrite\Client;
 use Appwrite\Services\Project;
-use Appwrite\Enums\Prompt;
 
 $client = (new Client())
     ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,9 +11,6 @@ $client = (new Client())
 
 $project = new Project($client);
 
-$result = $project->updateOAuth2Google(
-    clientId: '<CLIENT_ID>', // optional
-    clientSecret: '<CLIENT_SECRET>', // optional
-    prompt: [Prompt::NONE()], // optional
-    enabled: false // optional
+$result = $project->updateDenyCanonicalEmailPolicy(
+    enabled: false
 );```

--- a/docs/examples/project/update-deny-disposable-email-policy.md
+++ b/docs/examples/project/update-deny-disposable-email-policy.md
@@ -3,7 +3,6 @@
 
 use Appwrite\Client;
 use Appwrite\Services\Project;
-use Appwrite\Enums\Prompt;
 
 $client = (new Client())
     ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,9 +11,6 @@ $client = (new Client())
 
 $project = new Project($client);
 
-$result = $project->updateOAuth2Google(
-    clientId: '<CLIENT_ID>', // optional
-    clientSecret: '<CLIENT_SECRET>', // optional
-    prompt: [Prompt::NONE()], // optional
-    enabled: false // optional
+$result = $project->updateDenyDisposableEmailPolicy(
+    enabled: false
 );```

--- a/docs/examples/project/update-deny-free-email-policy.md
+++ b/docs/examples/project/update-deny-free-email-policy.md
@@ -3,7 +3,6 @@
 
 use Appwrite\Client;
 use Appwrite\Services\Project;
-use Appwrite\Enums\Prompt;
 
 $client = (new Client())
     ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
@@ -12,9 +11,6 @@ $client = (new Client())
 
 $project = new Project($client);
 
-$result = $project->updateOAuth2Google(
-    clientId: '<CLIENT_ID>', // optional
-    clientSecret: '<CLIENT_SECRET>', // optional
-    prompt: [Prompt::NONE()], // optional
-    enabled: false // optional
+$result = $project->updateDenyFreeEmailPolicy(
+    enabled: false
 );```

--- a/docs/project.md
+++ b/docs/project.md
@@ -218,7 +218,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/amazon
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Amazon OAuth2 app. For example: amzn1.application-oa2-client.87400c00000000000000000000063d5b2 |  |
-| clientSecret | string | 'Client Secret' of Amazon OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Amazon OAuth2 app. For example: 79ffe4000000000000000000000000000000000000000000000000000002de55 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -250,7 +250,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/auth0
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Auth0 OAuth2 app. For example: OaOkIA000000000000000000005KLSYq |  |
-| clientSecret | string | 'Client Secret' of Auth0 OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Auth0 OAuth2 app. For example: zXz0000-00000000000000000000000000000-00000000000000000000PJafnF |  |
 | endpoint | string | Domain of Auth0 instance. For example: example.us.auth0.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -266,7 +266,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/authentik
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Authentik OAuth2 app. For example: dTKOPa0000000000000000000000000000e7G8hv |  |
-| clientSecret | string | 'Client Secret' of Authentik OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Authentik OAuth2 app. For example: ntQadq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000Hp5WK |  |
 | endpoint | string | Domain of Authentik instance. For example: example.authentik.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -282,7 +282,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/autodesk
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Autodesk OAuth2 app. For example: 5zw90v00000000000000000000kVYXN7 |  |
-| clientSecret | string | 'Client Secret' of Autodesk OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Autodesk OAuth2 app. For example: 7I000000000000MW |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -297,7 +297,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/bitbucket
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | key | string | 'Key' of Bitbucket OAuth2 app. For example: Knt70000000000ByRc |  |
-| secret | string | 'Secret' of Bitbucket OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secret | string | 'Secret' of Bitbucket OAuth2 app. For example: NMfLZJ00000000000000000000TLQdDx |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -312,7 +312,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/bitly
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Bitly OAuth2 app. For example: d95151000000000000000000000000000067af9b |  |
-| clientSecret | string | 'Client Secret' of Bitly OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Bitly OAuth2 app. For example: a13e250000000000000000000000000000d73095 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -327,7 +327,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/box
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Box OAuth2 app. For example: deglcs00000000000000000000x2og6y |  |
-| clientSecret | string | 'Client Secret' of Box OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Box OAuth2 app. For example: OKM1f100000000000000000000eshEif |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -342,7 +342,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/dailymotion
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | apiKey | string | 'API Key' of Dailymotion OAuth2 app. For example: 07a9000000000000067f |  |
-| apiSecret | string | 'API Secret' of Dailymotion OAuth2 app. For example: <CLIENT_SECRET> |  |
+| apiSecret | string | 'API Secret' of Dailymotion OAuth2 app. For example: a399a90000000000000000000000000000d90639 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -357,7 +357,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/discord
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Discord OAuth2 app. For example: 950722000000343754 |  |
-| clientSecret | string | 'Client Secret' of Discord OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Discord OAuth2 app. For example: YmPXnM000000000000000000002zFg5D |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -372,7 +372,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/disqus
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | publicKey | string | 'Public Key, also known as API Key' of Disqus OAuth2 app. For example: cgegH70000000000000000000000000000000000000000000000000000Hr1nYX |  |
-| secretKey | string | 'Secret Key, also known as API Secret' of Disqus OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secretKey | string | 'Secret Key, also known as API Secret' of Disqus OAuth2 app. For example: W7Bykj00000000000000000000000000000000000000000000000000003o43w9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -387,7 +387,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/dropbox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | appKey | string | 'App Key' of Dropbox OAuth2 app. For example: jl000000000009t |  |
-| appSecret | string | 'App Secret' of Dropbox OAuth2 app. For example: <CLIENT_SECRET> |  |
+| appSecret | string | 'App Secret' of Dropbox OAuth2 app. For example: g200000000000vw |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -402,7 +402,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/etsy
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | keyString | string | 'Keystring' of Etsy OAuth2 app. For example: nsgzxh0000000000008j85a2 |  |
-| sharedSecret | string | 'Shared Secret' of Etsy OAuth2 app. For example: <CLIENT_SECRET> |  |
+| sharedSecret | string | 'Shared Secret' of Etsy OAuth2 app. For example: tp000000ru |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -417,7 +417,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/facebook
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | appId | string | 'App ID' of Facebook OAuth2 app. For example: 260600000007694 |  |
-| appSecret | string | 'App Secret' of Facebook OAuth2 app. For example: <CLIENT_SECRET> |  |
+| appSecret | string | 'App Secret' of Facebook OAuth2 app. For example: 2d0b2800000000000000000000d38af4 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -432,7 +432,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/figma
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Figma OAuth2 app. For example: byay5H0000000000VtiI40 |  |
-| clientSecret | string | 'Client Secret' of Figma OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Figma OAuth2 app. For example: yEpOYn0000000000000000004iIsU5 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -447,7 +447,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/fusionauth
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of FusionAuth OAuth2 app. For example: b2222c00-0000-0000-0000-000000862097 |  |
-| clientSecret | string | 'Client Secret' of FusionAuth OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of FusionAuth OAuth2 app. For example: Jx4s0C0000000000000000000000000000000wGqLsc |  |
 | endpoint | string | Domain of FusionAuth instance. For example: example.fusionauth.io |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -463,7 +463,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/github
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'OAuth2 app Client ID, or App ID' of GitHub OAuth2 app. For example: e4d87900000000540733. Example of wrong value: 370006 |  |
-| clientSecret | string | 'Client Secret' of GitHub OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of GitHub OAuth2 app. For example: 5e07c00000000000000000000000000000198bcc |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -478,7 +478,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/gitlab
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | applicationId | string | 'Application ID' of Gitlab OAuth2 app. For example: d41ffe0000000000000000000000000000000000000000000000000000d5e252 |  |
-| secret | string | 'Secret' of Gitlab OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secret | string | 'Secret' of Gitlab OAuth2 app. For example: gloas-838cfa0000000000000000000000000000000000000000000000000000ecbb38 |  |
 | endpoint | string | Endpoint URL of self-hosted GitLab instance. For example: https://gitlab.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -494,7 +494,8 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/google
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Google OAuth2 app. For example: 120000000095-92ifjb00000000000000000000g7ijfb.apps.googleusercontent.com |  |
-| clientSecret | string | 'Client Secret' of Google OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Google OAuth2 app. For example: GOCSPX-2k8gsR0000000000000000VNahJj |  |
+| prompt | array | Array of Google OAuth2 prompt values. If "none" is included, it must be the only element. "none" means: don't display any authentication or consent screens. Must not be specified with other values. "consent" means: prompt the user for consent. "select_account" means: prompt the user to select an account. |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -509,7 +510,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/keycloak
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Keycloak OAuth2 app. For example: appwrite-o0000000st-app |  |
-| clientSecret | string | 'Client Secret' of Keycloak OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Keycloak OAuth2 app. For example: jdjrJd00000000000000000000HUsaZO |  |
 | endpoint | string | Domain of Keycloak instance. For example: keycloak.example.com |  |
 | realmName | string | Keycloak realm name. For example: appwrite-realm |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
@@ -526,7 +527,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/kick
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Kick OAuth2 app. For example: 01KQ7C00000000000001MFHS32 |  |
-| clientSecret | string | 'Client Secret' of Kick OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Kick OAuth2 app. For example: 34ac5600000000000000000000000000000000000000000000000000e830c8b |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -541,7 +542,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/linkedin
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Linkedin OAuth2 app. For example: 770000000000dv |  |
-| primaryClientSecret | string | 'Primary Client Secret or Secondary Client Secret' of Linkedin OAuth2 app. For example: <CLIENT_SECRET> |  |
+| primaryClientSecret | string | 'Primary Client Secret or Secondary Client Secret' of Linkedin OAuth2 app. For example: WPL_AP1.2Bf0000000000000./HtlYw== |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -556,7 +557,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/microsoft
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | applicationId | string | 'Entra ID Application ID, also known as Client ID' of Microsoft OAuth2 app. For example: 00001111-aaaa-2222-bbbb-3333cccc4444 |  |
-| applicationSecret | string | 'Entra ID Application Secret, also known as Client Secret' of Microsoft OAuth2 app. For example: <CLIENT_SECRET> |  |
+| applicationSecret | string | 'Entra ID Application Secret, also known as Client Secret' of Microsoft OAuth2 app. For example: A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u |  |
 | tenant | string | Microsoft Entra ID tenant identifier. Use 'common', 'organizations', 'consumers' or a specific tenant ID. For example: common |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -572,7 +573,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/notion
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauthClientId | string | 'OAuth Client ID' of Notion OAuth2 app. For example: 341d8700-0000-0000-0000-000000446ee3 |  |
-| oauthClientSecret | string | 'OAuth Client Secret' of Notion OAuth2 app. For example: <CLIENT_SECRET> |  |
+| oauthClientSecret | string | 'OAuth Client Secret' of Notion OAuth2 app. For example: secret_dLUr4b000000000000000000000000000000lFHAa9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -587,7 +588,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/oidc
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Oidc OAuth2 app. For example: qibI2x0000000000000000000000000006L2YFoG |  |
-| clientSecret | string | 'Client Secret' of Oidc OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Oidc OAuth2 app. For example: Ah68ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003qpcHV |  |
 | wellKnownURL | string | OpenID Connect well-known configuration URL. When provided, authorization, token, and user info endpoints can be discovered automatically. For example: https://myoauth.com/.well-known/openid-configuration |  |
 | authorizationURL | string | OpenID Connect authorization endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/authorize |  |
 | tokenURL | string | OpenID Connect token endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/token |  |
@@ -606,7 +607,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/okta
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Okta OAuth2 app. For example: 0oa00000000000000698 |  |
-| clientSecret | string | 'Client Secret' of Okta OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Okta OAuth2 app. For example: Kiq0000000000000000000000000000000000000-00000000000H2L5-3SJ-vRV |  |
 | domain | string | Okta company domain. Required when enabling the provider. For example: trial-6400025.okta.com. Example of wrong value: trial-6400025-admin.okta.com, or https://trial-6400025.okta.com/ |  |
 | authorizationServerId | string | Custom Authorization Servers. Optional, can be left empty or unconfigured. For example: aus000000000000000h7z |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
@@ -623,7 +624,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/paypal
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Paypal OAuth2 app. For example: AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB |  |
-| secretKey | string | 'Secret Key 1 or Secret Key 2' of Paypal OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secretKey | string | 'Secret Key 1 or Secret Key 2' of Paypal OAuth2 app. For example: EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -638,7 +639,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/paypalSandbox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of PaypalSandbox OAuth2 app. For example: AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB |  |
-| secretKey | string | 'Secret Key 1 or Secret Key 2' of PaypalSandbox OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secretKey | string | 'Secret Key 1 or Secret Key 2' of PaypalSandbox OAuth2 app. For example: EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -653,7 +654,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/podio
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Podio OAuth2 app. For example: appwrite-o0000000st-app |  |
-| clientSecret | string | 'Client Secret' of Podio OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Podio OAuth2 app. For example: Rn247T0000000000000000000000000000000000000000000000000000W2zWTN |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -668,7 +669,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/salesforce
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | customerKey | string | 'Consumer Key' of Salesforce OAuth2 app. For example: 3MVG9I0000000000000000000000000000000000000000000000000000000000000000000000000C5Aejq |  |
-| customerSecret | string | 'Consumer Secret' of Salesforce OAuth2 app. For example: <CLIENT_SECRET> |  |
+| customerSecret | string | 'Consumer Secret' of Salesforce OAuth2 app. For example: 3w000000000000e2 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -683,7 +684,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/slack
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Slack OAuth2 app. For example: 23000000089.15000000000023 |  |
-| clientSecret | string | 'Client Secret' of Slack OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Slack OAuth2 app. For example: 81656000000000000000000000f3d2fd |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -698,7 +699,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/spotify
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Spotify OAuth2 app. For example: 6ec271000000000000000000009beace |  |
-| clientSecret | string | 'Client Secret' of Spotify OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Spotify OAuth2 app. For example: db068a000000000000000000008b5b9f |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -713,7 +714,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/stripe
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Stripe OAuth2 app. For example: ca_UKibXX0000000000000000000006byvR |  |
-| apiSecretKey | string | 'API Secret Key' of Stripe OAuth2 app. For example: <CLIENT_SECRET> |  |
+| apiSecretKey | string | 'API Secret Key' of Stripe OAuth2 app. For example: sk_51SfOd000000000000000000000000000000000000000000000000000000000000000000000000000000000000000QGWYfp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -728,7 +729,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/tradeshift
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauth2ClientId | string | 'OAuth2 Client ID' of Tradeshift OAuth2 app. For example: appwrite-tes00000.0000000000est-app |  |
-| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift OAuth2 app. For example: <CLIENT_SECRET> |  |
+| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift OAuth2 app. For example: 7cb52700-0000-0000-0000-000000ca5b83 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -743,7 +744,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/tradeshiftBox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauth2ClientId | string | 'OAuth2 Client ID' of Tradeshift Sandbox OAuth2 app. For example: appwrite-tes00000.0000000000est-app |  |
-| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift Sandbox OAuth2 app. For example: <CLIENT_SECRET> |  |
+| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift Sandbox OAuth2 app. For example: 7cb52700-0000-0000-0000-000000ca5b83 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -758,7 +759,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/twitch
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Twitch OAuth2 app. For example: vvi0in000000000000000000ikmt9p |  |
-| clientSecret | string | 'Client Secret' of Twitch OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Twitch OAuth2 app. For example: pmapue000000000000000000zylw3v |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -773,7 +774,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/wordpress
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of WordPress OAuth2 app. For example: 130005 |  |
-| clientSecret | string | 'Client Secret' of WordPress OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of WordPress OAuth2 app. For example: PlBfJS0000000000000000000000000000000000000000000000000000EdUZJk |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -788,7 +789,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/x
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | customerKey | string | 'Customer Key' of X OAuth2 app. For example: slzZV0000000000000NFLaWT |  |
-| secretKey | string | 'Secret Key' of X OAuth2 app. For example: <CLIENT_SECRET> |  |
+| secretKey | string | 'Secret Key' of X OAuth2 app. For example: tkEPkp00000000000000000000000000000000000000FTxbI9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -803,7 +804,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/yahoo
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID, also known as Customer Key' of Yahoo OAuth2 app. For example: dj0yJm000000000000000000000000000000000000000000000000000000000000000000000000000000000000Z4PWRm |  |
-| clientSecret | string | 'Client Secret, also known as Customer Secret' of Yahoo OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret, also known as Customer Secret' of Yahoo OAuth2 app. For example: cf978f0000000000000000000000000000c5e2e9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -818,7 +819,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/yandex
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Yandex OAuth2 app. For example: 6a8a6a0000000000000000000091483c |  |
-| clientSecret | string | 'Client Secret' of Yandex OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Yandex OAuth2 app. For example: bbf98500000000000000000000c75a63 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -833,7 +834,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/zoho
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Zoho OAuth2 app. For example: 1000.83C178000000000000000000RPNX0B |  |
-| clientSecret | string | 'Client Secret' of Zoho OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Zoho OAuth2 app. For example: fb5cac000000000000000000000000000000a68f6e |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -848,7 +849,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/zoom
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Zoom OAuth2 app. For example: QMAC00000000000000w0AQ |  |
-| clientSecret | string | 'Client Secret' of Zoom OAuth2 app. For example: <CLIENT_SECRET> |  |
+| clientSecret | string | 'Client Secret' of Zoom OAuth2 app. For example: GAWsG4000000000000000000007U01ON |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -1067,6 +1068,45 @@ GET https://cloud.appwrite.io/v1/project/policies
 | --- | --- | --- | --- |
 | queries | array | Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset | [] |
 | total | boolean | When set to false, the total count returned will be 0 and will not be calculated. | 1 |
+
+
+```http request
+PATCH https://cloud.appwrite.io/v1/project/policies/deny-canonical-email
+```
+
+** Configures if email aliases such as subaddresses and emails with suffixes are denied during new users sign-ups and email updates. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| enabled | boolean | Set whether or not to block email aliases during signup and email updates. |  |
+
+
+```http request
+PATCH https://cloud.appwrite.io/v1/project/policies/deny-disposable-email
+```
+
+** Configures if disposable emails from known temporary domains are denied during new users sign-ups and email updates. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| enabled | boolean | Set whether or not to block disposable email addresses during signup and email updates. |  |
+
+
+```http request
+PATCH https://cloud.appwrite.io/v1/project/policies/deny-free-email
+```
+
+** Configures if emails from free providers such as Gmail or Yahoo are denied during new users sign-ups and email updates. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| enabled | boolean | Set whether or not to block free email addresses during signup and email updates. |  |
 
 
 ```http request

--- a/src/Appwrite/Client.php
+++ b/src/Appwrite/Client.php
@@ -37,11 +37,11 @@ class Client
      */
     protected array $headers = [
         'content-type' => '',
-        'user-agent' => 'AppwritePHPSDK/23.1.0 ()',
+        'user-agent' => 'AppwritePHPSDK/23.1.1 ()',
         'x-sdk-name'=> 'PHP',
         'x-sdk-platform'=> 'server',
         'x-sdk-language'=> 'php',
-        'x-sdk-version'=> '23.1.0',
+        'x-sdk-version'=> '23.1.1',
     ];
 
     /**

--- a/src/Appwrite/Enums/BuildRuntime.php
+++ b/src/Appwrite/Enums/BuildRuntime.php
@@ -37,6 +37,9 @@ class BuildRuntime implements JsonSerializable
     private static BuildRuntime $PYTHONML311;
     private static BuildRuntime $PYTHONML312;
     private static BuildRuntime $PYTHONML313;
+    private static BuildRuntime $DENO121;
+    private static BuildRuntime $DENO124;
+    private static BuildRuntime $DENO135;
     private static BuildRuntime $DENO140;
     private static BuildRuntime $DENO146;
     private static BuildRuntime $DENO20;
@@ -329,6 +332,27 @@ class BuildRuntime implements JsonSerializable
             self::$PYTHONML313 = new BuildRuntime('python-ml-3.13');
         }
         return self::$PYTHONML313;
+    }
+    public static function DENO121(): BuildRuntime
+    {
+        if (!isset(self::$DENO121)) {
+            self::$DENO121 = new BuildRuntime('deno-1.21');
+        }
+        return self::$DENO121;
+    }
+    public static function DENO124(): BuildRuntime
+    {
+        if (!isset(self::$DENO124)) {
+            self::$DENO124 = new BuildRuntime('deno-1.24');
+        }
+        return self::$DENO124;
+    }
+    public static function DENO135(): BuildRuntime
+    {
+        if (!isset(self::$DENO135)) {
+            self::$DENO135 = new BuildRuntime('deno-1.35');
+        }
+        return self::$DENO135;
     }
     public static function DENO140(): BuildRuntime
     {
@@ -771,6 +795,9 @@ class BuildRuntime implements JsonSerializable
             'python-ml-3.11' => self::PYTHONML311(),
             'python-ml-3.12' => self::PYTHONML312(),
             'python-ml-3.13' => self::PYTHONML313(),
+            'deno-1.21' => self::DENO121(),
+            'deno-1.24' => self::DENO124(),
+            'deno-1.35' => self::DENO135(),
             'deno-1.40' => self::DENO140(),
             'deno-1.46' => self::DENO146(),
             'deno-2.0' => self::DENO20(),

--- a/src/Appwrite/Enums/OAuth2GooglePrompt.php
+++ b/src/Appwrite/Enums/OAuth2GooglePrompt.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Appwrite\Enums;
+
+use JsonSerializable;
+
+class OAuth2GooglePrompt implements JsonSerializable
+{
+    private static OAuth2GooglePrompt $NONE;
+    private static OAuth2GooglePrompt $CONSENT;
+    private static OAuth2GooglePrompt $SELECTACCOUNT;
+
+    private string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+
+    public static function NONE(): OAuth2GooglePrompt
+    {
+        if (!isset(self::$NONE)) {
+            self::$NONE = new OAuth2GooglePrompt('none');
+        }
+        return self::$NONE;
+    }
+    public static function CONSENT(): OAuth2GooglePrompt
+    {
+        if (!isset(self::$CONSENT)) {
+            self::$CONSENT = new OAuth2GooglePrompt('consent');
+        }
+        return self::$CONSENT;
+    }
+    public static function SELECTACCOUNT(): OAuth2GooglePrompt
+    {
+        if (!isset(self::$SELECTACCOUNT)) {
+            self::$SELECTACCOUNT = new OAuth2GooglePrompt('select_account');
+        }
+        return self::$SELECTACCOUNT;
+    }
+
+    public static function from(string $value): self
+    {
+        return match ($value) {
+            'none' => self::NONE(),
+            'consent' => self::CONSENT(),
+            'select_account' => self::SELECTACCOUNT(),
+            default => throw new \InvalidArgumentException('Unknown OAuth2GooglePrompt value: ' . $value),
+        };
+    }
+}

--- a/src/Appwrite/Enums/Prompt.php
+++ b/src/Appwrite/Enums/Prompt.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Appwrite\Enums;
+
+use JsonSerializable;
+
+class Prompt implements JsonSerializable
+{
+    private static Prompt $NONE;
+    private static Prompt $CONSENT;
+    private static Prompt $SELECTACCOUNT;
+
+    private string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+
+    public static function NONE(): Prompt
+    {
+        if (!isset(self::$NONE)) {
+            self::$NONE = new Prompt('none');
+        }
+        return self::$NONE;
+    }
+    public static function CONSENT(): Prompt
+    {
+        if (!isset(self::$CONSENT)) {
+            self::$CONSENT = new Prompt('consent');
+        }
+        return self::$CONSENT;
+    }
+    public static function SELECTACCOUNT(): Prompt
+    {
+        if (!isset(self::$SELECTACCOUNT)) {
+            self::$SELECTACCOUNT = new Prompt('select_account');
+        }
+        return self::$SELECTACCOUNT;
+    }
+
+    public static function from(string $value): self
+    {
+        return match ($value) {
+            'none' => self::NONE(),
+            'consent' => self::CONSENT(),
+            'select_account' => self::SELECTACCOUNT(),
+            default => throw new \InvalidArgumentException('Unknown Prompt value: ' . $value),
+        };
+    }
+}

--- a/src/Appwrite/Enums/Runtime.php
+++ b/src/Appwrite/Enums/Runtime.php
@@ -37,6 +37,9 @@ class Runtime implements JsonSerializable
     private static Runtime $PYTHONML311;
     private static Runtime $PYTHONML312;
     private static Runtime $PYTHONML313;
+    private static Runtime $DENO121;
+    private static Runtime $DENO124;
+    private static Runtime $DENO135;
     private static Runtime $DENO140;
     private static Runtime $DENO146;
     private static Runtime $DENO20;
@@ -329,6 +332,27 @@ class Runtime implements JsonSerializable
             self::$PYTHONML313 = new Runtime('python-ml-3.13');
         }
         return self::$PYTHONML313;
+    }
+    public static function DENO121(): Runtime
+    {
+        if (!isset(self::$DENO121)) {
+            self::$DENO121 = new Runtime('deno-1.21');
+        }
+        return self::$DENO121;
+    }
+    public static function DENO124(): Runtime
+    {
+        if (!isset(self::$DENO124)) {
+            self::$DENO124 = new Runtime('deno-1.24');
+        }
+        return self::$DENO124;
+    }
+    public static function DENO135(): Runtime
+    {
+        if (!isset(self::$DENO135)) {
+            self::$DENO135 = new Runtime('deno-1.35');
+        }
+        return self::$DENO135;
     }
     public static function DENO140(): Runtime
     {
@@ -771,6 +795,9 @@ class Runtime implements JsonSerializable
             'python-ml-3.11' => self::PYTHONML311(),
             'python-ml-3.12' => self::PYTHONML312(),
             'python-ml-3.13' => self::PYTHONML313(),
+            'deno-1.21' => self::DENO121(),
+            'deno-1.24' => self::DENO124(),
+            'deno-1.35' => self::DENO135(),
             'deno-1.40' => self::DENO140(),
             'deno-1.46' => self::DENO146(),
             'deno-2.0' => self::DENO20(),

--- a/src/Appwrite/Models/Database.php
+++ b/src/Appwrite/Models/Database.php
@@ -20,8 +20,8 @@ readonly class Database
      * @param string $updatedAt database update date in iso 8601 format.
      * @param bool $enabled if database is enabled. can be 'enabled' or 'disabled'. when disabled, the database is inaccessible to users, but remains accessible to server sdks using api keys.
      * @param DatabaseType $type database type.
-     * @param list<Index> $policies database backup policies.
-     * @param list<Collection> $archives database backup archives.
+     * @param list<BackupPolicy> $policies database backup policies.
+     * @param list<BackupArchive> $archives database backup archives.
      */
     public function __construct(
         public string $id,
@@ -74,13 +74,13 @@ readonly class Database
             type: static::hydrateTypedValue(DatabaseType::class, $data['type']),
             policies: is_array($data['policies'])
                 ? array_map(
-                    static fn (mixed $item): mixed => static::hydrateTypedValue(Index::class, $item),
+                    static fn (mixed $item): mixed => static::hydrateTypedValue(BackupPolicy::class, $item),
                     $data['policies']
                 )
                 : $data['policies'],
             archives: is_array($data['archives'])
                 ? array_map(
-                    static fn (mixed $item): mixed => static::hydrateTypedValue(Collection::class, $item),
+                    static fn (mixed $item): mixed => static::hydrateTypedValue(BackupArchive::class, $item),
                     $data['archives']
                 )
                 : $data['archives']

--- a/src/Appwrite/Models/OAuth2Google.php
+++ b/src/Appwrite/Models/OAuth2Google.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\Models;
 
+use Appwrite\Enums\OAuth2GooglePrompt;
+
 /**
  * OAuth2Google
  */
@@ -16,12 +18,14 @@ readonly class OAuth2Google
      * @param bool $enabled oauth2 provider is active and can be used to create sessions.
      * @param string $clientId google oauth2 client id.
      * @param string $clientSecret google oauth2 client secret.
+     * @param list<OAuth2GooglePrompt> $prompt google oauth2 prompt values.
      */
     public function __construct(
         public string $id,
         public bool $enabled,
         public string $clientId,
-        public string $clientSecret
+        public string $clientSecret,
+        public array $prompt
     ) {
     }
 
@@ -42,12 +46,21 @@ readonly class OAuth2Google
         if (!array_key_exists('clientSecret', $data)) {
             throw new \InvalidArgumentException('Missing required field "clientSecret" for ' . static::class . '.');
         }
+        if (!array_key_exists('prompt', $data)) {
+            throw new \InvalidArgumentException('Missing required field "prompt" for ' . static::class . '.');
+        }
 
         return new static(
             id: $data['$id'],
             enabled: $data['enabled'],
             clientId: $data['clientId'],
-            clientSecret: $data['clientSecret']
+            clientSecret: $data['clientSecret'],
+            prompt: is_array($data['prompt'])
+                ? array_map(
+                    static fn (mixed $item): mixed => static::hydrateTypedValue(OAuth2GooglePrompt::class, $item),
+                    $data['prompt']
+                )
+                : $data['prompt']
         );
     }
 
@@ -60,7 +73,8 @@ readonly class OAuth2Google
             '$id' => static::serializeValue($this->id),
             'enabled' => static::serializeValue($this->enabled),
             'clientId' => static::serializeValue($this->clientId),
-            'clientSecret' => static::serializeValue($this->clientSecret)
+            'clientSecret' => static::serializeValue($this->clientSecret),
+            'prompt' => static::serializeValue($this->prompt)
         ];
 
         return $result;

--- a/src/Appwrite/Services/Project.php
+++ b/src/Appwrite/Services/Project.php
@@ -8,6 +8,7 @@ use Appwrite\Service;
 use Appwrite\InputFile;
 use Appwrite\Enums\AuthMethod;
 use Appwrite\Enums\Scopes;
+use Appwrite\Enums\Prompt;
 use Appwrite\Enums\OAuthProvider;
 use Appwrite\Enums\ProjectPolicy;
 use Appwrite\Enums\ProtocolId;
@@ -1344,11 +1345,12 @@ class Project extends Service
      *
      * @param ?string $clientId
      * @param ?string $clientSecret
+     * @param ?array $prompt
      * @param ?bool $enabled
      * @throws AppwriteException
      * @return \Appwrite\Models\OAuth2Google
      */
-    public function updateOAuth2Google(?string $clientId = null, ?string $clientSecret = null, ?bool $enabled = null): \Appwrite\Models\OAuth2Google
+    public function updateOAuth2Google(?string $clientId = null, ?string $clientSecret = null, ?array $prompt = null, ?bool $enabled = null): \Appwrite\Models\OAuth2Google
     {
         $apiPath = str_replace(
             [],
@@ -1359,6 +1361,7 @@ class Project extends Service
         $apiParams = [];
         $apiParams['clientId'] = $clientId;
         $apiParams['clientSecret'] = $clientSecret;
+        $apiParams['prompt'] = $prompt;
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
@@ -3101,6 +3104,117 @@ class Project extends Service
         }
 
         return \Appwrite\Models\PolicyList::from($response);
+
+    }
+
+    /**
+     * Configures if email aliases such as subaddresses and emails with suffixes
+     * are denied during new users sign-ups and email updates.
+     *
+     * @param bool $enabled
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Project
+     */
+    public function updateDenyCanonicalEmailPolicy(bool $enabled): \Appwrite\Models\Project
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/project/policies/deny-canonical-email'
+        );
+
+        $apiParams = [];
+        $apiParams['enabled'] = $enabled;
+
+        $apiHeaders = [];
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Project::from($response);
+
+    }
+
+    /**
+     * Configures if disposable emails from known temporary domains are denied
+     * during new users sign-ups and email updates.
+     *
+     * @param bool $enabled
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Project
+     */
+    public function updateDenyDisposableEmailPolicy(bool $enabled): \Appwrite\Models\Project
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/project/policies/deny-disposable-email'
+        );
+
+        $apiParams = [];
+        $apiParams['enabled'] = $enabled;
+
+        $apiHeaders = [];
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Project::from($response);
+
+    }
+
+    /**
+     * Configures if emails from free providers such as Gmail or Yahoo are denied
+     * during new users sign-ups and email updates.
+     *
+     * @param bool $enabled
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Project
+     */
+    public function updateDenyFreeEmailPolicy(bool $enabled): \Appwrite\Models\Project
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/project/policies/deny-free-email'
+        );
+
+        $apiParams = [];
+        $apiParams['enabled'] = $enabled;
+
+        $apiHeaders = [];
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Project::from($response);
 
     }
 

--- a/tests/Appwrite/Services/DatabasesTest.php
+++ b/tests/Appwrite/Services/DatabasesTest.php
@@ -37,14 +37,14 @@ final class DatabasesTest extends TestCase
                     "policies" => array(
                         array(
                             "\$id" => "5e5ea5c16897e",
+                            "name" => "Hourly backups",
                             "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
+                            "services" => array(),
+                            "resources" => array(),
+                            "retention" => 7,
+                            "schedule" => "0 * * * *",
+                            "enabled" => true
                         )
                     ),
                     "archives" => array(
@@ -52,27 +52,13 @@ final class DatabasesTest extends TestCase
                             "\$id" => "5e5ea5c16897e",
                             "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$permissions" => array(),
-                            "databaseId" => "5e5ea5c16897e",
-                            "name" => "My Collection",
-                            "enabled" => true,
-                            "documentSecurity" => true,
-                            "attributes" => array(),
-                            "indexes" => array(
-                                array(
-                                    "\$id" => "5e5ea5c16897e",
-                                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                                    "key" => "index1",
-                                    "type" => "primary",
-                                    "status" => "available",
-                                    "error" => "string",
-                                    "attributes" => array(),
-                                    "lengths" => array()
-                                )
-                            ),
-                            "bytesMax" => 65535,
-                            "bytesUsed" => 1500
+                            "policyId" => "did8jx6ws45jana098ab7",
+                            "size" => 100000,
+                            "status" => "completed",
+                            "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                            "migrationId" => "did8jx6ws45jana098ab7",
+                            "services" => array(),
+                            "resources" => array()
                         )
                     )
                 )
@@ -100,14 +86,14 @@ final class DatabasesTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -115,27 +101,13 @@ final class DatabasesTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );
@@ -290,14 +262,14 @@ final class DatabasesTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -305,27 +277,13 @@ final class DatabasesTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );
@@ -353,14 +311,14 @@ final class DatabasesTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -368,27 +326,13 @@ final class DatabasesTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );

--- a/tests/Appwrite/Services/ProjectTest.php
+++ b/tests/Appwrite/Services/ProjectTest.php
@@ -8,6 +8,7 @@ use Mockery;
 use PHPUnit\Framework\TestCase;
 use Appwrite\Enums\AuthMethod;
 use Appwrite\Enums\Scopes;
+use Appwrite\Enums\Prompt;
 use Appwrite\Enums\OAuthProvider;
 use Appwrite\Enums\ProjectPolicy;
 use Appwrite\Enums\ProtocolId;
@@ -653,7 +654,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "amzn1.application-oa2-client.87400c00000000000000000000063d5b2",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "79ffe4000000000000000000000000000000000000000000000000000002de55"
         );
 
         $this->client
@@ -691,7 +692,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "OaOkIA000000000000000000005KLSYq",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "zXz0000-00000000000000000000000000000-00000000000000000000PJafnF",
             "endpoint" => "example.us.auth0.com"
         );
 
@@ -710,7 +711,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "dTKOPa0000000000000000000000000000e7G8hv",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "ntQadq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000Hp5WK",
             "endpoint" => "example.authentik.com"
         );
 
@@ -729,7 +730,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "5zw90v00000000000000000000kVYXN7",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "7I000000000000MW"
         );
 
         $this->client
@@ -747,7 +748,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "key" => "Knt70000000000ByRc",
-            "secret" => "<CLIENT_SECRET>"
+            "secret" => "NMfLZJ00000000000000000000TLQdDx"
         );
 
         $this->client
@@ -765,7 +766,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "d95151000000000000000000000000000067af9b",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "a13e250000000000000000000000000000d73095"
         );
 
         $this->client
@@ -783,7 +784,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "deglcs00000000000000000000x2og6y",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "OKM1f100000000000000000000eshEif"
         );
 
         $this->client
@@ -801,7 +802,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "apiKey" => "07a9000000000000067f",
-            "apiSecret" => "<CLIENT_SECRET>"
+            "apiSecret" => "a399a90000000000000000000000000000d90639"
         );
 
         $this->client
@@ -819,7 +820,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "950722000000343754",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "YmPXnM000000000000000000002zFg5D"
         );
 
         $this->client
@@ -837,7 +838,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "publicKey" => "cgegH70000000000000000000000000000000000000000000000000000Hr1nYX",
-            "secretKey" => "<CLIENT_SECRET>"
+            "secretKey" => "W7Bykj00000000000000000000000000000000000000000000000000003o43w9"
         );
 
         $this->client
@@ -855,7 +856,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "appKey" => "jl000000000009t",
-            "appSecret" => "<CLIENT_SECRET>"
+            "appSecret" => "g200000000000vw"
         );
 
         $this->client
@@ -873,7 +874,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "keyString" => "nsgzxh0000000000008j85a2",
-            "sharedSecret" => "<CLIENT_SECRET>"
+            "sharedSecret" => "tp000000ru"
         );
 
         $this->client
@@ -891,7 +892,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "appId" => "260600000007694",
-            "appSecret" => "<CLIENT_SECRET>"
+            "appSecret" => "2d0b2800000000000000000000d38af4"
         );
 
         $this->client
@@ -909,7 +910,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "byay5H0000000000VtiI40",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "yEpOYn0000000000000000004iIsU5"
         );
 
         $this->client
@@ -927,7 +928,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "b2222c00-0000-0000-0000-000000862097",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "Jx4s0C0000000000000000000000000000000wGqLsc",
             "endpoint" => "example.fusionauth.io"
         );
 
@@ -946,7 +947,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "e4d87900000000540733",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "5e07c00000000000000000000000000000198bcc"
         );
 
         $this->client
@@ -964,7 +965,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "applicationId" => "d41ffe0000000000000000000000000000000000000000000000000000d5e252",
-            "secret" => "<CLIENT_SECRET>",
+            "secret" => "gloas-838cfa0000000000000000000000000000000000000000000000000000ecbb38",
             "endpoint" => "https://gitlab.com"
         );
 
@@ -983,7 +984,8 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "120000000095-92ifjb00000000000000000000g7ijfb.apps.googleusercontent.com",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "GOCSPX-2k8gsR0000000000000000VNahJj",
+            "prompt" => array()
         );
 
         $this->client
@@ -1001,7 +1003,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "appwrite-o0000000st-app",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "jdjrJd00000000000000000000HUsaZO",
             "endpoint" => "keycloak.example.com",
             "realmName" => "appwrite-realm"
         );
@@ -1021,7 +1023,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "01KQ7C00000000000001MFHS32",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "34ac5600000000000000000000000000000000000000000000000000e830c8b"
         );
 
         $this->client
@@ -1039,7 +1041,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "770000000000dv",
-            "primaryClientSecret" => "<CLIENT_SECRET>"
+            "primaryClientSecret" => "WPL_AP1.2Bf0000000000000./HtlYw=="
         );
 
         $this->client
@@ -1057,7 +1059,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "applicationId" => "00001111-aaaa-2222-bbbb-3333cccc4444",
-            "applicationSecret" => "<CLIENT_SECRET>",
+            "applicationSecret" => "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u",
             "tenant" => "common"
         );
 
@@ -1076,7 +1078,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauthClientId" => "341d8700-0000-0000-0000-000000446ee3",
-            "oauthClientSecret" => "<CLIENT_SECRET>"
+            "oauthClientSecret" => "secret_dLUr4b000000000000000000000000000000lFHAa9"
         );
 
         $this->client
@@ -1094,7 +1096,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "qibI2x0000000000000000000000000006L2YFoG",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "Ah68ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003qpcHV",
             "wellKnownURL" => "https://myoauth.com/.well-known/openid-configuration",
             "authorizationURL" => "https://myoauth.com/oauth2/authorize",
             "tokenURL" => "https://myoauth.com/oauth2/token",
@@ -1116,7 +1118,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "0oa00000000000000698",
-            "clientSecret" => "<CLIENT_SECRET>",
+            "clientSecret" => "Kiq0000000000000000000000000000000000000-00000000000H2L5-3SJ-vRV",
             "domain" => "trial-6400025.okta.com",
             "authorizationServerId" => "aus000000000000000h7z"
         );
@@ -1136,7 +1138,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB",
-            "secretKey" => "<CLIENT_SECRET>"
+            "secretKey" => "EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp"
         );
 
         $this->client
@@ -1154,7 +1156,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB",
-            "secretKey" => "<CLIENT_SECRET>"
+            "secretKey" => "EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp"
         );
 
         $this->client
@@ -1172,7 +1174,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "appwrite-oauth-test-app",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "Rn247T0000000000000000000000000000000000000000000000000000W2zWTN"
         );
 
         $this->client
@@ -1190,7 +1192,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "customerKey" => "3MVG9I0000000000000000000000000000000000000000000000000000000000000000000000000C5Aejq",
-            "customerSecret" => "<CLIENT_SECRET>"
+            "customerSecret" => "3w000000000000e2"
         );
 
         $this->client
@@ -1208,7 +1210,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "23000000089.15000000000023",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "81656000000000000000000000f3d2fd"
         );
 
         $this->client
@@ -1226,7 +1228,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "6ec271000000000000000000009beace",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "db068a000000000000000000008b5b9f"
         );
 
         $this->client
@@ -1244,7 +1246,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "ca_UKibXX0000000000000000000006byvR",
-            "apiSecretKey" => "<CLIENT_SECRET>"
+            "apiSecretKey" => "sk_51SfOd000000000000000000000000000000000000000000000000000000000000000000000000000000000000000QGWYfp"
         );
 
         $this->client
@@ -1262,7 +1264,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauth2ClientId" => "appwrite-test-org.appwrite-test-app",
-            "oauth2ClientSecret" => "<CLIENT_SECRET>"
+            "oauth2ClientSecret" => "7cb52700-0000-0000-0000-000000ca5b83"
         );
 
         $this->client
@@ -1280,7 +1282,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauth2ClientId" => "appwrite-test-org.appwrite-test-app",
-            "oauth2ClientSecret" => "<CLIENT_SECRET>"
+            "oauth2ClientSecret" => "7cb52700-0000-0000-0000-000000ca5b83"
         );
 
         $this->client
@@ -1298,7 +1300,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "vvi0in000000000000000000ikmt9p",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "pmapue000000000000000000zylw3v"
         );
 
         $this->client
@@ -1316,7 +1318,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "130005",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "PlBfJS0000000000000000000000000000000000000000000000000000EdUZJk"
         );
 
         $this->client
@@ -1334,7 +1336,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "customerKey" => "slzZV0000000000000NFLaWT",
-            "secretKey" => "<CLIENT_SECRET>"
+            "secretKey" => "tkEPkp00000000000000000000000000000000000000FTxbI9"
         );
 
         $this->client
@@ -1352,7 +1354,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "dj0yJm000000000000000000000000000000000000000000000000000000000000000000000000000000000000Z4PWRm",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "cf978f0000000000000000000000000000c5e2e9"
         );
 
         $this->client
@@ -1370,7 +1372,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "6a8a6a0000000000000000000091483c",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "bbf98500000000000000000000c75a63"
         );
 
         $this->client
@@ -1388,7 +1390,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "1000.83C178000000000000000000RPNX0B",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "fb5cac000000000000000000000000000000a68f6e"
         );
 
         $this->client
@@ -1406,7 +1408,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "QMAC00000000000000w0AQ",
-            "clientSecret" => "<CLIENT_SECRET>"
+            "clientSecret" => "GAWsG4000000000000000000007U01ON"
         );
 
         $this->client
@@ -1425,7 +1427,7 @@ final class ProjectTest extends TestCase
                 "\$id" => "github",
                 "enabled" => true,
                 "applicationId" => "00001111-aaaa-2222-bbbb-3333cccc4444",
-                "applicationSecret" => "<CLIENT_SECRET>",
+                "applicationSecret" => "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u",
                 "tenant" => "common"
             ),
             array(
@@ -1756,6 +1758,519 @@ final class ProjectTest extends TestCase
         $response = $this->project->listPolicies();
 
         $this->assertInstanceOf(\Appwrite\Models\PolicyList::class, $response);
+    }
+
+    public function testMethodUpdateDenyCanonicalEmailPolicy(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "New Project",
+            "description" => "This is a new project.",
+            "teamId" => "1592981250",
+            "logo" => "5f5c451b403cb",
+            "url" => "5f5c451b403cb",
+            "legalName" => "Company LTD.",
+            "legalCountry" => "US",
+            "legalState" => "New York",
+            "legalCity" => "New York City.",
+            "legalAddress" => "620 Eighth Avenue, New York, NY 10018",
+            "legalTaxId" => "131102020",
+            "authDuration" => 60,
+            "authLimit" => 100,
+            "authSessionsLimit" => 10,
+            "authPasswordHistory" => 5,
+            "authPasswordDictionary" => true,
+            "authPersonalDataCheck" => true,
+            "authDisposableEmails" => true,
+            "authCanonicalEmails" => true,
+            "authFreeEmails" => true,
+            "authMockNumbers" => array(
+                array(
+                    "number" => "+1612842323",
+                    "otp" => "123456",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00"
+                )
+            ),
+            "authSessionAlerts" => true,
+            "authMembershipsUserName" => true,
+            "authMembershipsUserEmail" => true,
+            "authMembershipsMfa" => true,
+            "authMembershipsUserId" => true,
+            "authMembershipsUserPhone" => true,
+            "authInvalidateSessions" => true,
+            "oAuthProviders" => array(
+                array(
+                    "key" => "github",
+                    "name" => "GitHub",
+                    "appId" => "259125845563242502",
+                    "secret" => "[SECRET]",
+                    "enabled" => true
+                )
+            ),
+            "platforms" => array(),
+            "webhooks" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My Webhook",
+                    "url" => "https://example.com/webhook",
+                    "events" => array(),
+                    "tls" => true,
+                    "authUsername" => "username",
+                    "authPassword" => "password",
+                    "secret" => "ad3d581ca230e2b7059c545e5a",
+                    "enabled" => true,
+                    "logs" => "Failed to connect to remote server.",
+                    "attempts" => 10
+                )
+            ),
+            "keys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "scopes" => array(),
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "devKeys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "Dev API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "smtpEnabled" => true,
+            "smtpSenderName" => "John Appwrite",
+            "smtpSenderEmail" => "john@appwrite.io",
+            "smtpReplyToName" => "Support Team",
+            "smtpReplyToEmail" => "support@appwrite.io",
+            "smtpHost" => "mail.appwrite.io",
+            "smtpPort" => 25,
+            "smtpUsername" => "emailuser",
+            "smtpPassword" => "[SMTPPASSWORD]",
+            "smtpSecure" => "tls",
+            "pingCount" => 1,
+            "pingedAt" => "2020-10-15T06:38:00.000+00:00",
+            "labels" => array(),
+            "status" => "active",
+            "authEmailPassword" => true,
+            "authUsersAuthMagicURL" => true,
+            "authEmailOtp" => true,
+            "authAnonymous" => true,
+            "authInvites" => true,
+            "authJWT" => true,
+            "authPhone" => true,
+            "serviceStatusForAccount" => true,
+            "serviceStatusForAvatars" => true,
+            "serviceStatusForDatabases" => true,
+            "serviceStatusForTablesdb" => true,
+            "serviceStatusForLocale" => true,
+            "serviceStatusForHealth" => true,
+            "serviceStatusForProject" => true,
+            "serviceStatusForStorage" => true,
+            "serviceStatusForTeams" => true,
+            "serviceStatusForUsers" => true,
+            "serviceStatusForVcs" => true,
+            "serviceStatusForSites" => true,
+            "serviceStatusForFunctions" => true,
+            "serviceStatusForProxy" => true,
+            "serviceStatusForGraphql" => true,
+            "serviceStatusForMigrations" => true,
+            "serviceStatusForMessaging" => true,
+            "protocolStatusForRest" => true,
+            "protocolStatusForGraphql" => true,
+            "protocolStatusForWebsocket" => true,
+            "region" => "fra",
+            "billingLimits" => array(
+                "bandwidth" => 5,
+                "storage" => 150,
+                "users" => 200000,
+                "executions" => 750000,
+                "GBHours" => 100,
+                "imageTransformations" => 100,
+                "authPhone" => 10,
+                "budgetLimit" => 100
+            ),
+            "blocks" => array(
+                array(
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "resourceType" => "project",
+                    "resourceId" => "5e5ea5c16897e",
+                    "projectName" => "My Project",
+                    "region" => "fra",
+                    "organizationName" => "Acme Inc.",
+                    "organizationId" => "5e5ea5c16897e",
+                    "billingPlan" => "pro"
+                )
+            ),
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+
+        $response = $this->project->updateDenyCanonicalEmailPolicy(
+            true
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Project::class, $response);
+    }
+
+    public function testMethodUpdateDenyDisposableEmailPolicy(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "New Project",
+            "description" => "This is a new project.",
+            "teamId" => "1592981250",
+            "logo" => "5f5c451b403cb",
+            "url" => "5f5c451b403cb",
+            "legalName" => "Company LTD.",
+            "legalCountry" => "US",
+            "legalState" => "New York",
+            "legalCity" => "New York City.",
+            "legalAddress" => "620 Eighth Avenue, New York, NY 10018",
+            "legalTaxId" => "131102020",
+            "authDuration" => 60,
+            "authLimit" => 100,
+            "authSessionsLimit" => 10,
+            "authPasswordHistory" => 5,
+            "authPasswordDictionary" => true,
+            "authPersonalDataCheck" => true,
+            "authDisposableEmails" => true,
+            "authCanonicalEmails" => true,
+            "authFreeEmails" => true,
+            "authMockNumbers" => array(
+                array(
+                    "number" => "+1612842323",
+                    "otp" => "123456",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00"
+                )
+            ),
+            "authSessionAlerts" => true,
+            "authMembershipsUserName" => true,
+            "authMembershipsUserEmail" => true,
+            "authMembershipsMfa" => true,
+            "authMembershipsUserId" => true,
+            "authMembershipsUserPhone" => true,
+            "authInvalidateSessions" => true,
+            "oAuthProviders" => array(
+                array(
+                    "key" => "github",
+                    "name" => "GitHub",
+                    "appId" => "259125845563242502",
+                    "secret" => "[SECRET]",
+                    "enabled" => true
+                )
+            ),
+            "platforms" => array(),
+            "webhooks" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My Webhook",
+                    "url" => "https://example.com/webhook",
+                    "events" => array(),
+                    "tls" => true,
+                    "authUsername" => "username",
+                    "authPassword" => "password",
+                    "secret" => "ad3d581ca230e2b7059c545e5a",
+                    "enabled" => true,
+                    "logs" => "Failed to connect to remote server.",
+                    "attempts" => 10
+                )
+            ),
+            "keys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "scopes" => array(),
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "devKeys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "Dev API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "smtpEnabled" => true,
+            "smtpSenderName" => "John Appwrite",
+            "smtpSenderEmail" => "john@appwrite.io",
+            "smtpReplyToName" => "Support Team",
+            "smtpReplyToEmail" => "support@appwrite.io",
+            "smtpHost" => "mail.appwrite.io",
+            "smtpPort" => 25,
+            "smtpUsername" => "emailuser",
+            "smtpPassword" => "[SMTPPASSWORD]",
+            "smtpSecure" => "tls",
+            "pingCount" => 1,
+            "pingedAt" => "2020-10-15T06:38:00.000+00:00",
+            "labels" => array(),
+            "status" => "active",
+            "authEmailPassword" => true,
+            "authUsersAuthMagicURL" => true,
+            "authEmailOtp" => true,
+            "authAnonymous" => true,
+            "authInvites" => true,
+            "authJWT" => true,
+            "authPhone" => true,
+            "serviceStatusForAccount" => true,
+            "serviceStatusForAvatars" => true,
+            "serviceStatusForDatabases" => true,
+            "serviceStatusForTablesdb" => true,
+            "serviceStatusForLocale" => true,
+            "serviceStatusForHealth" => true,
+            "serviceStatusForProject" => true,
+            "serviceStatusForStorage" => true,
+            "serviceStatusForTeams" => true,
+            "serviceStatusForUsers" => true,
+            "serviceStatusForVcs" => true,
+            "serviceStatusForSites" => true,
+            "serviceStatusForFunctions" => true,
+            "serviceStatusForProxy" => true,
+            "serviceStatusForGraphql" => true,
+            "serviceStatusForMigrations" => true,
+            "serviceStatusForMessaging" => true,
+            "protocolStatusForRest" => true,
+            "protocolStatusForGraphql" => true,
+            "protocolStatusForWebsocket" => true,
+            "region" => "fra",
+            "billingLimits" => array(
+                "bandwidth" => 5,
+                "storage" => 150,
+                "users" => 200000,
+                "executions" => 750000,
+                "GBHours" => 100,
+                "imageTransformations" => 100,
+                "authPhone" => 10,
+                "budgetLimit" => 100
+            ),
+            "blocks" => array(
+                array(
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "resourceType" => "project",
+                    "resourceId" => "5e5ea5c16897e",
+                    "projectName" => "My Project",
+                    "region" => "fra",
+                    "organizationName" => "Acme Inc.",
+                    "organizationId" => "5e5ea5c16897e",
+                    "billingPlan" => "pro"
+                )
+            ),
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+
+        $response = $this->project->updateDenyDisposableEmailPolicy(
+            true
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Project::class, $response);
+    }
+
+    public function testMethodUpdateDenyFreeEmailPolicy(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "New Project",
+            "description" => "This is a new project.",
+            "teamId" => "1592981250",
+            "logo" => "5f5c451b403cb",
+            "url" => "5f5c451b403cb",
+            "legalName" => "Company LTD.",
+            "legalCountry" => "US",
+            "legalState" => "New York",
+            "legalCity" => "New York City.",
+            "legalAddress" => "620 Eighth Avenue, New York, NY 10018",
+            "legalTaxId" => "131102020",
+            "authDuration" => 60,
+            "authLimit" => 100,
+            "authSessionsLimit" => 10,
+            "authPasswordHistory" => 5,
+            "authPasswordDictionary" => true,
+            "authPersonalDataCheck" => true,
+            "authDisposableEmails" => true,
+            "authCanonicalEmails" => true,
+            "authFreeEmails" => true,
+            "authMockNumbers" => array(
+                array(
+                    "number" => "+1612842323",
+                    "otp" => "123456",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00"
+                )
+            ),
+            "authSessionAlerts" => true,
+            "authMembershipsUserName" => true,
+            "authMembershipsUserEmail" => true,
+            "authMembershipsMfa" => true,
+            "authMembershipsUserId" => true,
+            "authMembershipsUserPhone" => true,
+            "authInvalidateSessions" => true,
+            "oAuthProviders" => array(
+                array(
+                    "key" => "github",
+                    "name" => "GitHub",
+                    "appId" => "259125845563242502",
+                    "secret" => "[SECRET]",
+                    "enabled" => true
+                )
+            ),
+            "platforms" => array(),
+            "webhooks" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My Webhook",
+                    "url" => "https://example.com/webhook",
+                    "events" => array(),
+                    "tls" => true,
+                    "authUsername" => "username",
+                    "authPassword" => "password",
+                    "secret" => "ad3d581ca230e2b7059c545e5a",
+                    "enabled" => true,
+                    "logs" => "Failed to connect to remote server.",
+                    "attempts" => 10
+                )
+            ),
+            "keys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "My API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "scopes" => array(),
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "devKeys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "Dev API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "smtpEnabled" => true,
+            "smtpSenderName" => "John Appwrite",
+            "smtpSenderEmail" => "john@appwrite.io",
+            "smtpReplyToName" => "Support Team",
+            "smtpReplyToEmail" => "support@appwrite.io",
+            "smtpHost" => "mail.appwrite.io",
+            "smtpPort" => 25,
+            "smtpUsername" => "emailuser",
+            "smtpPassword" => "[SMTPPASSWORD]",
+            "smtpSecure" => "tls",
+            "pingCount" => 1,
+            "pingedAt" => "2020-10-15T06:38:00.000+00:00",
+            "labels" => array(),
+            "status" => "active",
+            "authEmailPassword" => true,
+            "authUsersAuthMagicURL" => true,
+            "authEmailOtp" => true,
+            "authAnonymous" => true,
+            "authInvites" => true,
+            "authJWT" => true,
+            "authPhone" => true,
+            "serviceStatusForAccount" => true,
+            "serviceStatusForAvatars" => true,
+            "serviceStatusForDatabases" => true,
+            "serviceStatusForTablesdb" => true,
+            "serviceStatusForLocale" => true,
+            "serviceStatusForHealth" => true,
+            "serviceStatusForProject" => true,
+            "serviceStatusForStorage" => true,
+            "serviceStatusForTeams" => true,
+            "serviceStatusForUsers" => true,
+            "serviceStatusForVcs" => true,
+            "serviceStatusForSites" => true,
+            "serviceStatusForFunctions" => true,
+            "serviceStatusForProxy" => true,
+            "serviceStatusForGraphql" => true,
+            "serviceStatusForMigrations" => true,
+            "serviceStatusForMessaging" => true,
+            "protocolStatusForRest" => true,
+            "protocolStatusForGraphql" => true,
+            "protocolStatusForWebsocket" => true,
+            "region" => "fra",
+            "billingLimits" => array(
+                "bandwidth" => 5,
+                "storage" => 150,
+                "users" => 200000,
+                "executions" => 750000,
+                "GBHours" => 100,
+                "imageTransformations" => 100,
+                "authPhone" => 10,
+                "budgetLimit" => 100
+            ),
+            "blocks" => array(
+                array(
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "resourceType" => "project",
+                    "resourceId" => "5e5ea5c16897e",
+                    "projectName" => "My Project",
+                    "region" => "fra",
+                    "organizationName" => "Acme Inc.",
+                    "organizationId" => "5e5ea5c16897e",
+                    "billingPlan" => "pro"
+                )
+            ),
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+
+        $response = $this->project->updateDenyFreeEmailPolicy(
+            true
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Project::class, $response);
     }
 
     public function testMethodUpdateMembershipPrivacyPolicy(): void

--- a/tests/Appwrite/Services/TablesDBTest.php
+++ b/tests/Appwrite/Services/TablesDBTest.php
@@ -37,14 +37,14 @@ final class TablesDBTest extends TestCase
                     "policies" => array(
                         array(
                             "\$id" => "5e5ea5c16897e",
+                            "name" => "Hourly backups",
                             "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
+                            "services" => array(),
+                            "resources" => array(),
+                            "retention" => 7,
+                            "schedule" => "0 * * * *",
+                            "enabled" => true
                         )
                     ),
                     "archives" => array(
@@ -52,27 +52,13 @@ final class TablesDBTest extends TestCase
                             "\$id" => "5e5ea5c16897e",
                             "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$permissions" => array(),
-                            "databaseId" => "5e5ea5c16897e",
-                            "name" => "My Collection",
-                            "enabled" => true,
-                            "documentSecurity" => true,
-                            "attributes" => array(),
-                            "indexes" => array(
-                                array(
-                                    "\$id" => "5e5ea5c16897e",
-                                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                                    "key" => "index1",
-                                    "type" => "primary",
-                                    "status" => "available",
-                                    "error" => "string",
-                                    "attributes" => array(),
-                                    "lengths" => array()
-                                )
-                            ),
-                            "bytesMax" => 65535,
-                            "bytesUsed" => 1500
+                            "policyId" => "did8jx6ws45jana098ab7",
+                            "size" => 100000,
+                            "status" => "completed",
+                            "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                            "migrationId" => "did8jx6ws45jana098ab7",
+                            "services" => array(),
+                            "resources" => array()
                         )
                     )
                 )
@@ -100,14 +86,14 @@ final class TablesDBTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -115,27 +101,13 @@ final class TablesDBTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );
@@ -290,14 +262,14 @@ final class TablesDBTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -305,27 +277,13 @@ final class TablesDBTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );
@@ -353,14 +311,14 @@ final class TablesDBTest extends TestCase
             "policies" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
+                    "name" => "Hourly backups",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "key" => "index1",
-                    "type" => "primary",
-                    "status" => "available",
-                    "error" => "string",
-                    "attributes" => array(),
-                    "lengths" => array()
+                    "services" => array(),
+                    "resources" => array(),
+                    "retention" => 7,
+                    "schedule" => "0 * * * *",
+                    "enabled" => true
                 )
             ),
             "archives" => array(
@@ -368,27 +326,13 @@ final class TablesDBTest extends TestCase
                     "\$id" => "5e5ea5c16897e",
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                    "\$permissions" => array(),
-                    "databaseId" => "5e5ea5c16897e",
-                    "name" => "My Collection",
-                    "enabled" => true,
-                    "documentSecurity" => true,
-                    "attributes" => array(),
-                    "indexes" => array(
-                        array(
-                            "\$id" => "5e5ea5c16897e",
-                            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
-                            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
-                            "key" => "index1",
-                            "type" => "primary",
-                            "status" => "available",
-                            "error" => "string",
-                            "attributes" => array(),
-                            "lengths" => array()
-                        )
-                    ),
-                    "bytesMax" => 65535,
-                    "bytesUsed" => 1500
+                    "policyId" => "did8jx6ws45jana098ab7",
+                    "size" => 100000,
+                    "status" => "completed",
+                    "startedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "migrationId" => "did8jx6ws45jana098ab7",
+                    "services" => array(),
+                    "resources" => array()
                 )
             )
         );


### PR DESCRIPTION
This PR updates the PHP SDK to version 23.1.1, regenerated from the Appwrite Cloud spec (cloud branch `backup-migration-multitype`).

## What's Changed

* Fixed: `Database` model `policies` and `archives` now hydrate as `BackupPolicy` / `BackupArchive` instead of `Index` / `Collection`
* Added: `bigint` create/update APIs for legacy Databases attributes and `TablesDB` columns
* Added: `OAuth2GooglePrompt` / `Prompt` enums and `prompt` support on `updateOAuth2Google`
* Added: `updateDenyCanonicalEmailPolicy` / `updateDenyDisposableEmailPolicy` / `updateDenyFreeEmailPolicy` Project endpoints
* Updated: `BuildRuntime` / `Runtime` enums
* Updated: key-list query filters extended with `key`, `resourceType`, `resourceId`, `secret`

### Why the `Database` fix

The `Database` response model previously declared `policies` with the `Index` schema and `archives` with the `Collection` schema. The server therefore serialised backup-policy/archive documents through the wrong shape — empty `status` strings — which broke `Database::from()` hydration (`IndexStatus::from('')` throws), aborting the Appwrite→Appwrite migration `database` resource report/transfer for any project that has a backup policy.

Version bump (`23.1.0` → `23.1.1`) and changelog included so the release is tag-ready on merge. Supersedes #69.
