### PR TITLE
chore: bump SDK version to 24.2.0

### DIFF
--- a/src/Appwrite/Client.php
+++ b/src/Appwrite/Client.php
@@ -37,11 +37,11 @@ class Client
      */
     protected array $headers = [
         'content-type' => '',
-        'user-agent' => 'AppwritePHPSDK/24.1.0 ()',
+        'user-agent' => 'AppwritePHPSDK/24.2.0 ()',
         'x-sdk-name'=> 'PHP',
         'x-sdk-platform'=> 'server',
         'x-sdk-language'=> 'php',
-        'x-sdk-version'=> '24.1.0',
+        'x-sdk-version'=> '24.2.0',
     ];
 
     /**


### PR DESCRIPTION
This PR bumps SDK version metadata to 24.2.0 after the concurrent chunk upload update.