### PR TITLE
feat: PHP SDK update for version 25.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 25.1.0
+
+* Added: `createSesProvider` and `updateSesProvider` to `messaging`
+* Added: `updateOAuth2Server` to `project` for OAuth2 server settings
+* Added: `updatePasswordStrengthPolicy` and `PolicyPasswordStrength` to `project`
+* Added: `getAuditsDB` health check to `health`
+* Added: `password-strength` to `ProjectPolicyId`
+* Added: `apps.read` and `apps.write` to `ProjectKeyScopes`
+
+
 ## 25.0.0
 
 * Breaking: Removed `githubImagine` and `googleImagine` from `ProjectOAuthProviderId`
@@ -8,7 +18,7 @@
 * Added: `Organization` service for managing projects and API keys
 * Added: `PolicyDenyAliasedEmail`, `PolicyDenyDisposableEmail`, and `PolicyDenyFreeEmail` policy models
 * Added: `deny-aliased-email`, `deny-disposable-email`, and `deny-free-email` to `ProjectPolicyId`
-* Added: `BrowserTheme`, `HealthQueueName`, `OrganizationKeyScopes`, and `Region` enums
+* Replaced: `BrowserTheme`, `HealthQueueName`, `OrganizationKeyScopes`, and `Region` enums
 * Added: `dart-3.12` and `flutter-3.44` runtimes
 * Added: `ProjectList` model and new attributes on `Function`, `Site`, and `UsageGauge`
 * Updated: `functions`, `sites`, `usage`, `health`, and `avatars` services

--- a/docs/account.md
+++ b/docs/account.md
@@ -321,7 +321,7 @@ PATCH https://cloud.appwrite.io/v1/account/password
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | password | string | New user password. Must be at least 8 chars. |  |
-| oldPassword | string | Current user password. Must be at least 8 chars. |  |
+| oldPassword | string | Current user password. Max length: 256 chars. |  |
 
 
 ```http request

--- a/docs/examples/account/update-password.md
+++ b/docs/examples/account/update-password.md
@@ -13,5 +13,5 @@ $account = new Account($client);
 
 $result = $account->updatePassword(
     password: '',
-    oldPassword: 'password' // optional
+    oldPassword: '<OLD_PASSWORD>' // optional
 );```

--- a/docs/examples/health/get-audits-db.md
+++ b/docs/examples/health/get-audits-db.md
@@ -1,0 +1,15 @@
+```php
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Health;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setKey('<YOUR_API_KEY>'); // Your secret API key
+
+$health = new Health($client);
+
+$result = $health->getAuditsDB();
+```

--- a/docs/examples/messaging/create-ses-provider.md
+++ b/docs/examples/messaging/create-ses-provider.md
@@ -1,0 +1,25 @@
+```php
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Messaging;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setKey('<YOUR_API_KEY>'); // Your secret API key
+
+$messaging = new Messaging($client);
+
+$result = $messaging->createSesProvider(
+    providerId: '<PROVIDER_ID>',
+    name: '<NAME>',
+    accessKey: '<ACCESS_KEY>', // optional
+    secretKey: '<SECRET_KEY>', // optional
+    region: '<REGION>', // optional
+    fromName: '<FROM_NAME>', // optional
+    fromEmail: 'email@example.com', // optional
+    replyToName: '<REPLY_TO_NAME>', // optional
+    replyToEmail: 'email@example.com', // optional
+    enabled: false // optional
+);```

--- a/docs/examples/messaging/update-ses-provider.md
+++ b/docs/examples/messaging/update-ses-provider.md
@@ -1,0 +1,25 @@
+```php
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Messaging;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setKey('<YOUR_API_KEY>'); // Your secret API key
+
+$messaging = new Messaging($client);
+
+$result = $messaging->updateSesProvider(
+    providerId: '<PROVIDER_ID>',
+    name: '<NAME>', // optional
+    enabled: false, // optional
+    accessKey: '<ACCESS_KEY>', // optional
+    secretKey: '<SECRET_KEY>', // optional
+    region: '<REGION>', // optional
+    fromName: '<FROM_NAME>', // optional
+    fromEmail: 'email@example.com', // optional
+    replyToName: '<REPLY_TO_NAME>', // optional
+    replyToEmail: '<REPLY_TO_EMAIL>' // optional
+);```

--- a/docs/examples/project/update-o-auth-2-server.md
+++ b/docs/examples/project/update-o-auth-2-server.md
@@ -1,0 +1,23 @@
+```php
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Project;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setKey('<YOUR_API_KEY>'); // Your secret API key
+
+$project = new Project($client);
+
+$result = $project->updateOAuth2Server(
+    enabled: false,
+    authorizationUrl: 'https://example.com',
+    scopes: [], // optional
+    accessTokenDuration: 60, // optional
+    refreshTokenDuration: 60, // optional
+    publicAccessTokenDuration: 60, // optional
+    publicRefreshTokenDuration: 60, // optional
+    confidentialPkce: false // optional
+);```

--- a/docs/examples/project/update-password-strength-policy.md
+++ b/docs/examples/project/update-password-strength-policy.md
@@ -1,0 +1,20 @@
+```php
+<?php
+
+use Appwrite\Client;
+use Appwrite\Services\Project;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    ->setProject('<YOUR_PROJECT_ID>') // Your project ID
+    ->setKey('<YOUR_API_KEY>'); // Your secret API key
+
+$project = new Project($client);
+
+$result = $project->updatePasswordStrengthPolicy(
+    min: 8, // optional
+    uppercase: false, // optional
+    lowercase: false, // optional
+    number: false, // optional
+    symbols: false // optional
+);```

--- a/docs/health.md
+++ b/docs/health.md
@@ -16,6 +16,14 @@ GET https://cloud.appwrite.io/v1/health/anti-virus
 
 
 ```http request
+GET https://cloud.appwrite.io/v1/health/audits-db
+```
+
+** Check the database that backs the audit and activity store. When the connection is reachable the endpoint returns a passing status with its response time.
+ **
+
+
+```http request
 GET https://cloud.appwrite.io/v1/health/cache
 ```
 

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -583,6 +583,50 @@ PATCH https://cloud.appwrite.io/v1/messaging/providers/sendgrid/{providerId}
 
 
 ```http request
+POST https://cloud.appwrite.io/v1/messaging/providers/ses
+```
+
+** Create a new Amazon SES provider. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| providerId | string | Provider ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars. |  |
+| name | string | Provider name. |  |
+| accessKey | string | AWS access key ID. |  |
+| secretKey | string | AWS secret access key. |  |
+| region | string | AWS region, for example us-east-1. |  |
+| fromName | string | Sender Name. |  |
+| fromEmail | string | Sender email address. |  |
+| replyToName | string | Name set in the reply to field for the mail. Default value is sender name. |  |
+| replyToEmail | string | Email set in the reply to field for the mail. Default value is sender email. |  |
+| enabled | boolean | Set as enabled. |  |
+
+
+```http request
+PATCH https://cloud.appwrite.io/v1/messaging/providers/ses/{providerId}
+```
+
+** Update an Amazon SES provider by its unique ID. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| providerId | string | **Required** Provider ID. |  |
+| name | string | Provider name. |  |
+| enabled | boolean | Set as enabled. |  |
+| accessKey | string | AWS access key ID. |  |
+| secretKey | string | AWS secret access key. |  |
+| region | string | AWS region, for example us-east-1. |  |
+| fromName | string | Sender Name. |  |
+| fromEmail | string | Sender email address. |  |
+| replyToName | string | Name set in the Reply To field for the mail. Default value is Sender Name. |  |
+| replyToEmail | string | Email set in the Reply To field for the mail. Default value is Sender Email. |  |
+
+
+```http request
 POST https://cloud.appwrite.io/v1/messaging/providers/smtp
 ```
 

--- a/docs/organization.md
+++ b/docs/organization.md
@@ -100,7 +100,7 @@ POST https://cloud.appwrite.io/v1/organization/projects
 | --- | --- | --- | --- |
 | projectId | string | Unique Id. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, and hyphen. Can't start with a special char. Max length is 36 chars. |  |
 | name | string | Project name. Max length: 128 chars. |  |
-| region | string | Project Region. | fra |
+| region | string | Project Region. |  |
 
 
 ```http request

--- a/docs/project.md
+++ b/docs/project.md
@@ -215,6 +215,26 @@ GET https://cloud.appwrite.io/v1/project/oauth2
 
 
 ```http request
+PUT https://cloud.appwrite.io/v1/project/oauth2-server
+```
+
+** Update the OAuth2 server (OIDC provider) configuration. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| enabled | boolean | Enable or disable the OAuth2 server. |  |
+| authorizationUrl | string | URL to your application with consent screen. |  |
+| scopes | array | List of allowed OAuth2 scopes. Maximum of 100 scopes are allowed, each up to 128 characters long. | [] |
+| accessTokenDuration | integer | Access token duration in seconds for confidential clients (server-side apps that authenticate with a client secret). Leave empty to use default 8 hours. |  |
+| refreshTokenDuration | integer | Refresh token duration in seconds for confidential clients (server-side apps that authenticate with a client secret). Leave empty to use default 1 year. |  |
+| publicAccessTokenDuration | integer | Access token duration in seconds for public clients (SPAs, mobile, and native apps that cannot keep a client secret). Leave empty to use default 1 hour. |  |
+| publicRefreshTokenDuration | integer | Refresh token duration in seconds for public clients (SPAs, mobile, and native apps that cannot keep a client secret). Leave empty to use default 30 days. |  |
+| confidentialPkce | boolean | When enabled, PKCE is required for confidential clients (server-side flows using client_secret). PKCE is always required for public clients regardless of this setting. |  |
+
+
+```http request
 PATCH https://cloud.appwrite.io/v1/project/oauth2/amazon
 ```
 
@@ -225,7 +245,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/amazon
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Amazon OAuth2 app. For example: amzn1.application-oa2-client.87400c00000000000000000000063d5b2 |  |
-| clientSecret | string | 'Client Secret' of Amazon OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Amazon OAuth2 app. For example: 79ffe4000000000000000000000000000000000000000000000000000002de55 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -257,7 +277,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/auth0
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Auth0 OAuth2 app. For example: OaOkIA000000000000000000005KLSYq |  |
-| clientSecret | string | 'Client Secret' of Auth0 OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Auth0 OAuth2 app. For example: zXz0000-00000000000000000000000000000-00000000000000000000PJafnF |  |
 | endpoint | string | Domain of Auth0 instance. For example: example.us.auth0.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -273,7 +293,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/authentik
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Authentik OAuth2 app. For example: dTKOPa0000000000000000000000000000e7G8hv |  |
-| clientSecret | string | 'Client Secret' of Authentik OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Authentik OAuth2 app. For example: ntQadq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000Hp5WK |  |
 | endpoint | string | Domain of Authentik instance. For example: example.authentik.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -289,7 +309,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/autodesk
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Autodesk OAuth2 app. For example: 5zw90v00000000000000000000kVYXN7 |  |
-| clientSecret | string | 'Client Secret' of Autodesk OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Autodesk OAuth2 app. For example: 7I000000000000MW |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -304,7 +324,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/bitbucket
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | key | string | 'Key' of Bitbucket OAuth2 app. For example: Knt70000000000ByRc |  |
-| secret | string | 'Secret' of Bitbucket OAuth2 app. For example: your-oauth2-client-secret |  |
+| secret | string | 'Secret' of Bitbucket OAuth2 app. For example: NMfLZJ00000000000000000000TLQdDx |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -319,7 +339,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/bitly
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Bitly OAuth2 app. For example: d95151000000000000000000000000000067af9b |  |
-| clientSecret | string | 'Client Secret' of Bitly OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Bitly OAuth2 app. For example: a13e250000000000000000000000000000d73095 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -334,7 +354,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/box
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Box OAuth2 app. For example: deglcs00000000000000000000x2og6y |  |
-| clientSecret | string | 'Client Secret' of Box OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Box OAuth2 app. For example: OKM1f100000000000000000000eshEif |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -349,7 +369,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/dailymotion
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | apiKey | string | 'API Key' of Dailymotion OAuth2 app. For example: 07a9000000000000067f |  |
-| apiSecret | string | 'API Secret' of Dailymotion OAuth2 app. For example: your-oauth2-client-secret |  |
+| apiSecret | string | 'API Secret' of Dailymotion OAuth2 app. For example: a399a90000000000000000000000000000d90639 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -364,7 +384,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/discord
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Discord OAuth2 app. For example: 950722000000343754 |  |
-| clientSecret | string | 'Client Secret' of Discord OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Discord OAuth2 app. For example: YmPXnM000000000000000000002zFg5D |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -379,7 +399,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/disqus
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | publicKey | string | 'Public Key, also known as API Key' of Disqus OAuth2 app. For example: cgegH70000000000000000000000000000000000000000000000000000Hr1nYX |  |
-| secretKey | string | 'Secret Key, also known as API Secret' of Disqus OAuth2 app. For example: your-oauth2-client-secret |  |
+| secretKey | string | 'Secret Key, also known as API Secret' of Disqus OAuth2 app. For example: W7Bykj00000000000000000000000000000000000000000000000000003o43w9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -394,7 +414,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/dropbox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | appKey | string | 'App Key' of Dropbox OAuth2 app. For example: jl000000000009t |  |
-| appSecret | string | 'App Secret' of Dropbox OAuth2 app. For example: your-oauth2-client-secret |  |
+| appSecret | string | 'App Secret' of Dropbox OAuth2 app. For example: g200000000000vw |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -409,7 +429,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/etsy
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | keyString | string | 'Keystring' of Etsy OAuth2 app. For example: nsgzxh0000000000008j85a2 |  |
-| sharedSecret | string | 'Shared Secret' of Etsy OAuth2 app. For example: your-oauth2-client-secret |  |
+| sharedSecret | string | 'Shared Secret' of Etsy OAuth2 app. For example: tp000000ru |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -424,7 +444,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/facebook
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | appId | string | 'App ID' of Facebook OAuth2 app. For example: 260600000007694 |  |
-| appSecret | string | 'App Secret' of Facebook OAuth2 app. For example: your-oauth2-client-secret |  |
+| appSecret | string | 'App Secret' of Facebook OAuth2 app. For example: 2d0b2800000000000000000000d38af4 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -439,7 +459,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/figma
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Figma OAuth2 app. For example: byay5H0000000000VtiI40 |  |
-| clientSecret | string | 'Client Secret' of Figma OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Figma OAuth2 app. For example: yEpOYn0000000000000000004iIsU5 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -454,7 +474,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/fusionauth
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of FusionAuth OAuth2 app. For example: b2222c00-0000-0000-0000-000000862097 |  |
-| clientSecret | string | 'Client Secret' of FusionAuth OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of FusionAuth OAuth2 app. For example: Jx4s0C0000000000000000000000000000000wGqLsc |  |
 | endpoint | string | Domain of FusionAuth instance. For example: example.fusionauth.io |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -470,7 +490,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/github
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'OAuth2 app Client ID, or App ID' of GitHub OAuth2 app. For example: e4d87900000000540733. Example of wrong value: 370006 |  |
-| clientSecret | string | 'Client Secret' of GitHub OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of GitHub OAuth2 app. For example: 5e07c00000000000000000000000000000198bcc |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -485,7 +505,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/gitlab
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | applicationId | string | 'Application ID' of Gitlab OAuth2 app. For example: d41ffe0000000000000000000000000000000000000000000000000000d5e252 |  |
-| secret | string | 'Secret' of Gitlab OAuth2 app. For example: your-oauth2-client-secret |  |
+| secret | string | 'Secret' of Gitlab OAuth2 app. For example: gloas-838cfa0000000000000000000000000000000000000000000000000000ecbb38 |  |
 | endpoint | string | Endpoint URL of self-hosted GitLab instance. For example: https://gitlab.com |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -501,7 +521,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/google
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Google OAuth2 app. For example: 120000000095-92ifjb00000000000000000000g7ijfb.apps.googleusercontent.com |  |
-| clientSecret | string | 'Client Secret' of Google OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Google OAuth2 app. For example: GOCSPX-2k8gsR0000000000000000VNahJj |  |
 | prompt | array | Array of Google OAuth2 prompt values. If "none" is included, it must be the only element. "none" means: don't display any authentication or consent screens. Must not be specified with other values. "consent" means: prompt the user for consent. "select_account" means: prompt the user to select an account. |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -517,7 +537,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/keycloak
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Keycloak OAuth2 app. For example: appwrite-o0000000st-app |  |
-| clientSecret | string | 'Client Secret' of Keycloak OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Keycloak OAuth2 app. For example: jdjrJd00000000000000000000HUsaZO |  |
 | endpoint | string | Domain of Keycloak instance. For example: keycloak.example.com |  |
 | realmName | string | Keycloak realm name. For example: appwrite-realm |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
@@ -534,7 +554,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/kick
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Kick OAuth2 app. For example: 01KQ7C00000000000001MFHS32 |  |
-| clientSecret | string | 'Client Secret' of Kick OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Kick OAuth2 app. For example: 34ac5600000000000000000000000000000000000000000000000000e830c8b |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -549,7 +569,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/linkedin
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Linkedin OAuth2 app. For example: 770000000000dv |  |
-| primaryClientSecret | string | 'Primary Client Secret or Secondary Client Secret' of Linkedin OAuth2 app. For example: your-oauth2-client-secret |  |
+| primaryClientSecret | string | 'Primary Client Secret or Secondary Client Secret' of Linkedin OAuth2 app. For example: WPL_AP1.2Bf0000000000000./HtlYw== |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -564,7 +584,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/microsoft
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | applicationId | string | 'Entra ID Application ID, also known as Client ID' of Microsoft OAuth2 app. For example: 00001111-aaaa-2222-bbbb-3333cccc4444 |  |
-| applicationSecret | string | 'Entra ID Application Secret, also known as Client Secret' of Microsoft OAuth2 app. For example: your-oauth2-client-secret |  |
+| applicationSecret | string | 'Entra ID Application Secret, also known as Client Secret' of Microsoft OAuth2 app. For example: A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u |  |
 | tenant | string | Microsoft Entra ID tenant identifier. Use 'common', 'organizations', 'consumers' or a specific tenant ID. For example: common |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
@@ -580,7 +600,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/notion
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauthClientId | string | 'OAuth Client ID' of Notion OAuth2 app. For example: 341d8700-0000-0000-0000-000000446ee3 |  |
-| oauthClientSecret | string | 'OAuth Client Secret' of Notion OAuth2 app. For example: your-oauth2-client-secret |  |
+| oauthClientSecret | string | 'OAuth Client Secret' of Notion OAuth2 app. For example: secret_dLUr4b000000000000000000000000000000lFHAa9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -595,7 +615,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/oidc
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Oidc OAuth2 app. For example: qibI2x0000000000000000000000000006L2YFoG |  |
-| clientSecret | string | 'Client Secret' of Oidc OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Oidc OAuth2 app. For example: Ah68ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003qpcHV |  |
 | wellKnownURL | string | OpenID Connect well-known configuration URL. When provided, authorization, token, and user info endpoints can be discovered automatically. For example: https://myoauth.com/.well-known/openid-configuration |  |
 | authorizationURL | string | OpenID Connect authorization endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/authorize |  |
 | tokenURL | string | OpenID Connect token endpoint URL. Required when wellKnownURL is not provided. For example: https://myoauth.com/oauth2/token |  |
@@ -614,7 +634,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/okta
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Okta OAuth2 app. For example: 0oa00000000000000698 |  |
-| clientSecret | string | 'Client Secret' of Okta OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Okta OAuth2 app. For example: Kiq0000000000000000000000000000000000000-00000000000H2L5-3SJ-vRV |  |
 | domain | string | Okta company domain. Required when enabling the provider. For example: trial-6400025.okta.com. Example of wrong value: trial-6400025-admin.okta.com, or https://trial-6400025.okta.com/ |  |
 | authorizationServerId | string | Custom Authorization Servers. Optional, can be left empty or unconfigured. For example: aus000000000000000h7z |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
@@ -631,7 +651,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/paypal
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Paypal OAuth2 app. For example: AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB |  |
-| secretKey | string | 'Secret Key 1 or Secret Key 2' of Paypal OAuth2 app. For example: your-oauth2-client-secret |  |
+| secretKey | string | 'Secret Key 1 or Secret Key 2' of Paypal OAuth2 app. For example: EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -646,7 +666,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/paypalSandbox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of PaypalSandbox OAuth2 app. For example: AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB |  |
-| secretKey | string | 'Secret Key 1 or Secret Key 2' of PaypalSandbox OAuth2 app. For example: your-oauth2-client-secret |  |
+| secretKey | string | 'Secret Key 1 or Secret Key 2' of PaypalSandbox OAuth2 app. For example: EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -661,7 +681,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/podio
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Podio OAuth2 app. For example: appwrite-o0000000st-app |  |
-| clientSecret | string | 'Client Secret' of Podio OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Podio OAuth2 app. For example: Rn247T0000000000000000000000000000000000000000000000000000W2zWTN |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -676,7 +696,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/salesforce
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | customerKey | string | 'Consumer Key' of Salesforce OAuth2 app. For example: 3MVG9I0000000000000000000000000000000000000000000000000000000000000000000000000C5Aejq |  |
-| customerSecret | string | 'Consumer Secret' of Salesforce OAuth2 app. For example: your-oauth2-client-secret |  |
+| customerSecret | string | 'Consumer Secret' of Salesforce OAuth2 app. For example: 3w000000000000e2 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -691,7 +711,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/slack
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Slack OAuth2 app. For example: 23000000089.15000000000023 |  |
-| clientSecret | string | 'Client Secret' of Slack OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Slack OAuth2 app. For example: 81656000000000000000000000f3d2fd |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -706,7 +726,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/spotify
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Spotify OAuth2 app. For example: 6ec271000000000000000000009beace |  |
-| clientSecret | string | 'Client Secret' of Spotify OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Spotify OAuth2 app. For example: db068a000000000000000000008b5b9f |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -721,7 +741,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/stripe
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Stripe OAuth2 app. For example: ca_UKibXX0000000000000000000006byvR |  |
-| apiSecretKey | string | 'API Secret Key' of Stripe OAuth2 app. For example: your-oauth2-client-secret |  |
+| apiSecretKey | string | 'API Secret Key' of Stripe OAuth2 app. For example: sk_51SfOd000000000000000000000000000000000000000000000000000000000000000000000000000000000000000QGWYfp |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -736,7 +756,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/tradeshift
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauth2ClientId | string | 'OAuth2 Client ID' of Tradeshift OAuth2 app. For example: appwrite-tes00000.0000000000est-app |  |
-| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift OAuth2 app. For example: your-oauth2-client-secret |  |
+| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift OAuth2 app. For example: 7cb52700-0000-0000-0000-000000ca5b83 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -751,7 +771,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/tradeshiftBox
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | oauth2ClientId | string | 'OAuth2 Client ID' of Tradeshift Sandbox OAuth2 app. For example: appwrite-tes00000.0000000000est-app |  |
-| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift Sandbox OAuth2 app. For example: your-oauth2-client-secret |  |
+| oauth2ClientSecret | string | 'OAuth2 Client Secret' of Tradeshift Sandbox OAuth2 app. For example: 7cb52700-0000-0000-0000-000000ca5b83 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -766,7 +786,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/twitch
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Twitch OAuth2 app. For example: vvi0in000000000000000000ikmt9p |  |
-| clientSecret | string | 'Client Secret' of Twitch OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Twitch OAuth2 app. For example: pmapue000000000000000000zylw3v |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -781,7 +801,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/wordpress
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of WordPress OAuth2 app. For example: 130005 |  |
-| clientSecret | string | 'Client Secret' of WordPress OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of WordPress OAuth2 app. For example: PlBfJS0000000000000000000000000000000000000000000000000000EdUZJk |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -796,7 +816,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/x
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | customerKey | string | 'Customer Key' of X OAuth2 app. For example: slzZV0000000000000NFLaWT |  |
-| secretKey | string | 'Secret Key' of X OAuth2 app. For example: your-oauth2-client-secret |  |
+| secretKey | string | 'Secret Key' of X OAuth2 app. For example: tkEPkp00000000000000000000000000000000000000FTxbI9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -811,7 +831,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/yahoo
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID, also known as Customer Key' of Yahoo OAuth2 app. For example: dj0yJm000000000000000000000000000000000000000000000000000000000000000000000000000000000000Z4PWRm |  |
-| clientSecret | string | 'Client Secret, also known as Customer Secret' of Yahoo OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret, also known as Customer Secret' of Yahoo OAuth2 app. For example: cf978f0000000000000000000000000000c5e2e9 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -826,7 +846,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/yandex
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Yandex OAuth2 app. For example: 6a8a6a0000000000000000000091483c |  |
-| clientSecret | string | 'Client Secret' of Yandex OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Yandex OAuth2 app. For example: bbf98500000000000000000000c75a63 |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -841,7 +861,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/zoho
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Zoho OAuth2 app. For example: 1000.83C178000000000000000000RPNX0B |  |
-| clientSecret | string | 'Client Secret' of Zoho OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Zoho OAuth2 app. For example: fb5cac000000000000000000000000000000a68f6e |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -856,7 +876,7 @@ PATCH https://cloud.appwrite.io/v1/project/oauth2/zoom
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
 | clientId | string | 'Client ID' of Zoom OAuth2 app. For example: QMAC00000000000000w0AQ |  |
-| clientSecret | string | 'Client Secret' of Zoom OAuth2 app. For example: your-oauth2-client-secret |  |
+| clientSecret | string | 'Client Secret' of Zoom OAuth2 app. For example: GAWsG4000000000000000000007U01ON |  |
 | enabled | boolean | OAuth2 sign-in method status. Set to true to enable new session creation. Setting to true will trigger end-to-end credentials validation, and will throw if the credentials are invalid. |  |
 
 
@@ -1175,6 +1195,23 @@ PATCH https://cloud.appwrite.io/v1/project/policies/password-personal-data
 
 
 ```http request
+PATCH https://cloud.appwrite.io/v1/project/policies/password-strength
+```
+
+** Update the password strength requirements for users in the project. **
+
+### Parameters
+
+| Field Name | Type | Description | Default |
+| --- | --- | --- | --- |
+| min | integer | Minimum password length. Value must be between 8 and 256. Default is 8. |  |
+| uppercase | boolean | Whether passwords must include at least one uppercase letter. |  |
+| lowercase | boolean | Whether passwords must include at least one lowercase letter. |  |
+| number | boolean | Whether passwords must include at least one number. |  |
+| symbols | boolean | Whether passwords must include at least one symbol. |  |
+
+
+```http request
 PATCH https://cloud.appwrite.io/v1/project/policies/session-alert
 ```
 
@@ -1249,7 +1286,7 @@ GET https://cloud.appwrite.io/v1/project/policies/{policyId}
 
 | Field Name | Type | Description | Default |
 | --- | --- | --- | --- |
-| policyId | string | **Required** Policy ID. Can be one of: password-dictionary, password-history, password-personal-data, session-alert, session-duration, session-invalidation, session-limit, user-limit, membership-privacy, deny-aliased-email, deny-disposable-email, deny-free-email. |  |
+| policyId | string | **Required** Policy ID. Can be one of: password-dictionary, password-history, password-strength, password-personal-data, session-alert, session-duration, session-invalidation, session-limit, user-limit, membership-privacy, deny-aliased-email, deny-disposable-email, deny-free-email. |  |
 
 
 ```http request

--- a/src/Appwrite/Client.php
+++ b/src/Appwrite/Client.php
@@ -37,12 +37,19 @@ class Client
      */
     protected array $headers = [
         'content-type' => '',
-        'user-agent' => 'AppwritePHPSDK/25.0.0 ()',
+        'user-agent' => 'AppwritePHPSDK/25.1.0 ()',
         'x-sdk-name'=> 'PHP',
         'x-sdk-platform'=> 'server',
         'x-sdk-language'=> 'php',
-        'x-sdk-version'=> '25.0.0',
+        'x-sdk-version'=> '25.1.0',
     ];
+
+    /**
+     * Auth/config values used by generated service methods.
+     *
+     * @var array
+     */
+    protected array $config = [];
 
     /**
      * Timeout in seconds
@@ -78,7 +85,7 @@ class Client
      */
     public function setProject(string $value): Client
     {
-        $this->addHeader('X-Appwrite-Project', $value);
+        $this->config['project'] = $value;
 
         return $this;
     }
@@ -95,6 +102,7 @@ class Client
     public function setKey(string $value): Client
     {
         $this->addHeader('X-Appwrite-Key', $value);
+        $this->config['key'] = $value;
 
         return $this;
     }
@@ -111,6 +119,7 @@ class Client
     public function setJWT(string $value): Client
     {
         $this->addHeader('X-Appwrite-JWT', $value);
+        $this->config['jwt'] = $value;
 
         return $this;
     }
@@ -125,6 +134,7 @@ class Client
     public function setLocale(string $value): Client
     {
         $this->addHeader('X-Appwrite-Locale', $value);
+        $this->config['locale'] = $value;
 
         return $this;
     }
@@ -141,6 +151,7 @@ class Client
     public function setSession(string $value): Client
     {
         $this->addHeader('X-Appwrite-Session', $value);
+        $this->config['session'] = $value;
 
         return $this;
     }
@@ -157,6 +168,7 @@ class Client
     public function setForwardedUserAgent(string $value): Client
     {
         $this->addHeader('X-Forwarded-User-Agent', $value);
+        $this->config['forwardeduseragent'] = $value;
 
         return $this;
     }
@@ -173,6 +185,7 @@ class Client
     public function setDevKey(string $value): Client
     {
         $this->addHeader('X-Appwrite-Dev-Key', $value);
+        $this->config['devkey'] = $value;
 
         return $this;
     }
@@ -189,6 +202,7 @@ class Client
     public function setCookie(string $value): Client
     {
         $this->addHeader('Cookie', $value);
+        $this->config['cookie'] = $value;
 
         return $this;
     }
@@ -205,6 +219,7 @@ class Client
     public function setImpersonateUserId(string $value): Client
     {
         $this->addHeader('X-Appwrite-Impersonate-User-Id', $value);
+        $this->config['impersonateuserid'] = $value;
 
         return $this;
     }
@@ -221,6 +236,7 @@ class Client
     public function setImpersonateUserEmail(string $value): Client
     {
         $this->addHeader('X-Appwrite-Impersonate-User-Email', $value);
+        $this->config['impersonateuseremail'] = $value;
 
         return $this;
     }
@@ -237,10 +253,16 @@ class Client
     public function setImpersonateUserPhone(string $value): Client
     {
         $this->addHeader('X-Appwrite-Impersonate-User-Phone', $value);
+        $this->config['impersonateuserphone'] = $value;
 
         return $this;
     }
 
+
+    public function getConfig(string $key): string
+    {
+        return $this->config[$key] ?? '';
+    }
 
     /***
      * @param bool $status
@@ -333,7 +355,8 @@ class Client
     )
     {
         $headers = array_merge($this->headers, $headers);
-        $ch = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
+        $querySeparator = str_contains($path, '?') ? '&' : '?';
+        $ch = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? $querySeparator . http_build_query($params) : ''));
         $responseHeaders = [];
 
         switch ($headers['content-type']) {

--- a/src/Appwrite/Enums/ProjectKeyScopes.php
+++ b/src/Appwrite/Enums/ProjectKeyScopes.php
@@ -99,6 +99,8 @@ class ProjectKeyScopes implements JsonSerializable
     private static ProjectKeyScopes $DOMAINSREAD;
     private static ProjectKeyScopes $DOMAINSWRITE;
     private static ProjectKeyScopes $EVENTSREAD;
+    private static ProjectKeyScopes $APPSREAD;
+    private static ProjectKeyScopes $APPSWRITE;
     private static ProjectKeyScopes $USAGEREAD;
 
     private string $value;
@@ -769,6 +771,20 @@ class ProjectKeyScopes implements JsonSerializable
         }
         return self::$EVENTSREAD;
     }
+    public static function APPSREAD(): ProjectKeyScopes
+    {
+        if (!isset(self::$APPSREAD)) {
+            self::$APPSREAD = new ProjectKeyScopes('apps.read');
+        }
+        return self::$APPSREAD;
+    }
+    public static function APPSWRITE(): ProjectKeyScopes
+    {
+        if (!isset(self::$APPSWRITE)) {
+            self::$APPSWRITE = new ProjectKeyScopes('apps.write');
+        }
+        return self::$APPSWRITE;
+    }
     public static function USAGEREAD(): ProjectKeyScopes
     {
         if (!isset(self::$USAGEREAD)) {
@@ -873,6 +889,8 @@ class ProjectKeyScopes implements JsonSerializable
             'domains.read' => self::DOMAINSREAD(),
             'domains.write' => self::DOMAINSWRITE(),
             'events.read' => self::EVENTSREAD(),
+            'apps.read' => self::APPSREAD(),
+            'apps.write' => self::APPSWRITE(),
             'usage.read' => self::USAGEREAD(),
             default => throw new \InvalidArgumentException('Unknown ProjectKeyScopes value: ' . $value),
         };

--- a/src/Appwrite/Enums/ProjectPolicyId.php
+++ b/src/Appwrite/Enums/ProjectPolicyId.php
@@ -8,6 +8,7 @@ class ProjectPolicyId implements JsonSerializable
 {
     private static ProjectPolicyId $PASSWORDDICTIONARY;
     private static ProjectPolicyId $PASSWORDHISTORY;
+    private static ProjectPolicyId $PASSWORDSTRENGTH;
     private static ProjectPolicyId $PASSWORDPERSONALDATA;
     private static ProjectPolicyId $SESSIONALERT;
     private static ProjectPolicyId $SESSIONDURATION;
@@ -49,6 +50,13 @@ class ProjectPolicyId implements JsonSerializable
             self::$PASSWORDHISTORY = new ProjectPolicyId('password-history');
         }
         return self::$PASSWORDHISTORY;
+    }
+    public static function PASSWORDSTRENGTH(): ProjectPolicyId
+    {
+        if (!isset(self::$PASSWORDSTRENGTH)) {
+            self::$PASSWORDSTRENGTH = new ProjectPolicyId('password-strength');
+        }
+        return self::$PASSWORDSTRENGTH;
     }
     public static function PASSWORDPERSONALDATA(): ProjectPolicyId
     {
@@ -126,6 +134,7 @@ class ProjectPolicyId implements JsonSerializable
         return match ($value) {
             'password-dictionary' => self::PASSWORDDICTIONARY(),
             'password-history' => self::PASSWORDHISTORY(),
+            'password-strength' => self::PASSWORDSTRENGTH(),
             'password-personal-data' => self::PASSWORDPERSONALDATA(),
             'session-alert' => self::SESSIONALERT(),
             'session-duration' => self::SESSIONDURATION(),

--- a/src/Appwrite/Models/PolicyPasswordStrength.php
+++ b/src/Appwrite/Models/PolicyPasswordStrength.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Appwrite\Models;
+
+/**
+ * Policy Password Strength
+ */
+readonly class PolicyPasswordStrength
+{
+    use ArraySerializable;
+
+    /**
+     * PolicyPasswordStrength constructor.
+     *
+     * @param string $id policy id.
+     * @param int $min minimum password length required for user passwords.
+     * @param bool $uppercase whether passwords must include at least one uppercase letter.
+     * @param bool $lowercase whether passwords must include at least one lowercase letter.
+     * @param bool $number whether passwords must include at least one number.
+     * @param bool $symbols whether passwords must include at least one symbol.
+     */
+    public function __construct(
+        public string $id,
+        public int $min,
+        public bool $uppercase,
+        public bool $lowercase,
+        public bool $number,
+        public bool $symbols
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function from(array $data): static
+    {
+        if (!array_key_exists('$id', $data)) {
+            throw new \InvalidArgumentException('Missing required field "$id" for ' . static::class . '.');
+        }
+        if (!array_key_exists('min', $data)) {
+            throw new \InvalidArgumentException('Missing required field "min" for ' . static::class . '.');
+        }
+        if (!array_key_exists('uppercase', $data)) {
+            throw new \InvalidArgumentException('Missing required field "uppercase" for ' . static::class . '.');
+        }
+        if (!array_key_exists('lowercase', $data)) {
+            throw new \InvalidArgumentException('Missing required field "lowercase" for ' . static::class . '.');
+        }
+        if (!array_key_exists('number', $data)) {
+            throw new \InvalidArgumentException('Missing required field "number" for ' . static::class . '.');
+        }
+        if (!array_key_exists('symbols', $data)) {
+            throw new \InvalidArgumentException('Missing required field "symbols" for ' . static::class . '.');
+        }
+
+        return new static(
+            id: $data['$id'],
+            min: $data['min'],
+            uppercase: $data['uppercase'],
+            lowercase: $data['lowercase'],
+            number: $data['number'],
+            symbols: $data['symbols']
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $result = [
+            '$id' => static::serializeValue($this->id),
+            'min' => static::serializeValue($this->min),
+            'uppercase' => static::serializeValue($this->uppercase),
+            'lowercase' => static::serializeValue($this->lowercase),
+            'number' => static::serializeValue($this->number),
+            'symbols' => static::serializeValue($this->symbols)
+        ];
+
+        return $result;
+    }
+}

--- a/src/Appwrite/Models/Project.php
+++ b/src/Appwrite/Models/Project.php
@@ -17,6 +17,7 @@ readonly class Project
      * @param string $updatedAt project update date in iso 8601 format.
      * @param string $name project name.
      * @param string $teamId project team id.
+     * @param string $region project region
      * @param list<DevKey> $devKeys deprecated since 1.9.5: list of dev keys.
      * @param bool $smtpEnabled status for custom smtp
      * @param string $smtpSenderName smtp sender name
@@ -35,9 +36,17 @@ readonly class Project
      * @param list<ProjectAuthMethod> $authMethods list of auth methods.
      * @param list<ProjectService> $services list of services.
      * @param list<ProjectProtocol> $protocols list of protocols.
-     * @param string $region project region
      * @param list<Block> $blocks project blocks information
      * @param string $consoleAccessedAt last time the project was accessed via console. used with plan's projectinactivitydays to determine if project is paused.
+     * @param bool $oAuth2ServerEnabled oauth2 server status
+     * @param string $oAuth2ServerAuthorizationUrl oauth2 server authorization url
+     * @param array $oAuth2ServerScopes oauth2 server allowed scopes
+     * @param int $oAuth2ServerAccessTokenDuration oauth2 server access token duration in seconds for confidential clients
+     * @param int $oAuth2ServerRefreshTokenDuration oauth2 server refresh token duration in seconds for confidential clients
+     * @param int $oAuth2ServerPublicAccessTokenDuration oauth2 server access token duration in seconds for public clients (spas, mobile, native)
+     * @param int $oAuth2ServerPublicRefreshTokenDuration oauth2 server refresh token duration in seconds for public clients (spas, mobile, native)
+     * @param bool $oAuth2ServerConfidentialPkce when enabled, pkce is required for confidential clients (server-side flows using client_secret). pkce is always required for public clients regardless of this setting.
+     * @param string $oAuth2ServerDiscoveryUrl oauth2 server discovery url
      * @param BillingLimits|null $billingLimits billing limits reached
      */
     public function __construct(
@@ -46,6 +55,7 @@ readonly class Project
         public string $updatedAt,
         public string $name,
         public string $teamId,
+        public string $region,
         public array $devKeys,
         public bool $smtpEnabled,
         public string $smtpSenderName,
@@ -64,9 +74,17 @@ readonly class Project
         public array $authMethods,
         public array $services,
         public array $protocols,
-        public string $region,
         public array $blocks,
         public string $consoleAccessedAt,
+        public bool $oAuth2ServerEnabled,
+        public string $oAuth2ServerAuthorizationUrl,
+        public array $oAuth2ServerScopes,
+        public int $oAuth2ServerAccessTokenDuration,
+        public int $oAuth2ServerRefreshTokenDuration,
+        public int $oAuth2ServerPublicAccessTokenDuration,
+        public int $oAuth2ServerPublicRefreshTokenDuration,
+        public bool $oAuth2ServerConfidentialPkce,
+        public string $oAuth2ServerDiscoveryUrl,
         public ?BillingLimits $billingLimits = null
     ) {
     }
@@ -90,6 +108,9 @@ readonly class Project
         }
         if (!array_key_exists('teamId', $data)) {
             throw new \InvalidArgumentException('Missing required field "teamId" for ' . static::class . '.');
+        }
+        if (!array_key_exists('region', $data)) {
+            throw new \InvalidArgumentException('Missing required field "region" for ' . static::class . '.');
         }
         if (!array_key_exists('devKeys', $data)) {
             throw new \InvalidArgumentException('Missing required field "devKeys" for ' . static::class . '.');
@@ -145,14 +166,38 @@ readonly class Project
         if (!array_key_exists('protocols', $data)) {
             throw new \InvalidArgumentException('Missing required field "protocols" for ' . static::class . '.');
         }
-        if (!array_key_exists('region', $data)) {
-            throw new \InvalidArgumentException('Missing required field "region" for ' . static::class . '.');
-        }
         if (!array_key_exists('blocks', $data)) {
             throw new \InvalidArgumentException('Missing required field "blocks" for ' . static::class . '.');
         }
         if (!array_key_exists('consoleAccessedAt', $data)) {
             throw new \InvalidArgumentException('Missing required field "consoleAccessedAt" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerEnabled', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerEnabled" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerAuthorizationUrl', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerAuthorizationUrl" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerScopes', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerScopes" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerAccessTokenDuration', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerAccessTokenDuration" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerRefreshTokenDuration', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerRefreshTokenDuration" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerPublicAccessTokenDuration', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerPublicAccessTokenDuration" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerPublicRefreshTokenDuration', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerPublicRefreshTokenDuration" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerConfidentialPkce', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerConfidentialPkce" for ' . static::class . '.');
+        }
+        if (!array_key_exists('oAuth2ServerDiscoveryUrl', $data)) {
+            throw new \InvalidArgumentException('Missing required field "oAuth2ServerDiscoveryUrl" for ' . static::class . '.');
         }
 
         return new static(
@@ -161,6 +206,7 @@ readonly class Project
             updatedAt: $data['$updatedAt'],
             name: $data['name'],
             teamId: $data['teamId'],
+            region: $data['region'],
             devKeys: is_array($data['devKeys'])
                 ? array_map(
                     static fn (mixed $item): mixed => static::hydrateTypedValue(DevKey::class, $item),
@@ -199,7 +245,6 @@ readonly class Project
                     $data['protocols']
                 )
                 : $data['protocols'],
-            region: $data['region'],
             blocks: is_array($data['blocks'])
                 ? array_map(
                     static fn (mixed $item): mixed => static::hydrateTypedValue(Block::class, $item),
@@ -207,6 +252,15 @@ readonly class Project
                 )
                 : $data['blocks'],
             consoleAccessedAt: $data['consoleAccessedAt'],
+            oAuth2ServerEnabled: $data['oAuth2ServerEnabled'],
+            oAuth2ServerAuthorizationUrl: $data['oAuth2ServerAuthorizationUrl'],
+            oAuth2ServerScopes: $data['oAuth2ServerScopes'],
+            oAuth2ServerAccessTokenDuration: $data['oAuth2ServerAccessTokenDuration'],
+            oAuth2ServerRefreshTokenDuration: $data['oAuth2ServerRefreshTokenDuration'],
+            oAuth2ServerPublicAccessTokenDuration: $data['oAuth2ServerPublicAccessTokenDuration'],
+            oAuth2ServerPublicRefreshTokenDuration: $data['oAuth2ServerPublicRefreshTokenDuration'],
+            oAuth2ServerConfidentialPkce: $data['oAuth2ServerConfidentialPkce'],
+            oAuth2ServerDiscoveryUrl: $data['oAuth2ServerDiscoveryUrl'],
             billingLimits: array_key_exists('billingLimits', $data) ? static::hydrateTypedValue(BillingLimits::class, $data['billingLimits'], true) : null
         );
     }
@@ -222,6 +276,7 @@ readonly class Project
             '$updatedAt' => static::serializeValue($this->updatedAt),
             'name' => static::serializeValue($this->name),
             'teamId' => static::serializeValue($this->teamId),
+            'region' => static::serializeValue($this->region),
             'devKeys' => static::serializeValue($this->devKeys),
             'smtpEnabled' => static::serializeValue($this->smtpEnabled),
             'smtpSenderName' => static::serializeValue($this->smtpSenderName),
@@ -240,10 +295,18 @@ readonly class Project
             'authMethods' => static::serializeValue($this->authMethods),
             'services' => static::serializeValue($this->services),
             'protocols' => static::serializeValue($this->protocols),
-            'region' => static::serializeValue($this->region),
-            'billingLimits' => static::serializeValue($this->billingLimits),
             'blocks' => static::serializeValue($this->blocks),
-            'consoleAccessedAt' => static::serializeValue($this->consoleAccessedAt)
+            'consoleAccessedAt' => static::serializeValue($this->consoleAccessedAt),
+            'billingLimits' => static::serializeValue($this->billingLimits),
+            'oAuth2ServerEnabled' => static::serializeValue($this->oAuth2ServerEnabled),
+            'oAuth2ServerAuthorizationUrl' => static::serializeValue($this->oAuth2ServerAuthorizationUrl),
+            'oAuth2ServerScopes' => static::serializeValue($this->oAuth2ServerScopes),
+            'oAuth2ServerAccessTokenDuration' => static::serializeValue($this->oAuth2ServerAccessTokenDuration),
+            'oAuth2ServerRefreshTokenDuration' => static::serializeValue($this->oAuth2ServerRefreshTokenDuration),
+            'oAuth2ServerPublicAccessTokenDuration' => static::serializeValue($this->oAuth2ServerPublicAccessTokenDuration),
+            'oAuth2ServerPublicRefreshTokenDuration' => static::serializeValue($this->oAuth2ServerPublicRefreshTokenDuration),
+            'oAuth2ServerConfidentialPkce' => static::serializeValue($this->oAuth2ServerConfidentialPkce),
+            'oAuth2ServerDiscoveryUrl' => static::serializeValue($this->oAuth2ServerDiscoveryUrl)
         ];
 
         return $result;

--- a/src/Appwrite/Services/Account.php
+++ b/src/Appwrite/Services/Account.php
@@ -34,6 +34,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -84,6 +85,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -129,6 +131,7 @@ class Account extends Service
         $apiParams['password'] = $password;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -173,6 +176,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -208,6 +212,7 @@ class Account extends Service
         $apiParams['identityId'] = $identityId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -247,6 +252,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -292,6 +298,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -327,6 +334,7 @@ class Account extends Service
         $apiParams['mfa'] = $mfa;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -366,6 +374,7 @@ class Account extends Service
         $apiParams['type'] = $type;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -406,6 +415,7 @@ class Account extends Service
         $apiParams['otp'] = $otp;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -442,6 +452,7 @@ class Account extends Service
         $apiParams['type'] = $type;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -476,6 +487,7 @@ class Account extends Service
         $apiParams['factor'] = $factor;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -518,6 +530,7 @@ class Account extends Service
         $apiParams['otp'] = $otp;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -552,6 +565,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -588,6 +602,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -625,6 +640,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -662,6 +678,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -698,6 +715,7 @@ class Account extends Service
         $apiParams['name'] = $name;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -741,6 +759,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -783,6 +802,7 @@ class Account extends Service
         $apiParams['password'] = $password;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -817,6 +837,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -854,6 +875,7 @@ class Account extends Service
         $apiParams['prefs'] = $prefs;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -899,6 +921,7 @@ class Account extends Service
         $apiParams['url'] = $url;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -948,6 +971,7 @@ class Account extends Service
         $apiParams['password'] = $password;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -983,6 +1007,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1017,6 +1042,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1053,6 +1079,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1096,6 +1123,7 @@ class Account extends Service
         $apiParams['password'] = $password;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1139,6 +1167,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1182,6 +1211,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1222,6 +1252,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1259,6 +1290,7 @@ class Account extends Service
         $apiParams['sessionId'] = $sessionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1296,6 +1328,7 @@ class Account extends Service
         $apiParams['sessionId'] = $sessionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1336,6 +1369,7 @@ class Account extends Service
         $apiParams['sessionId'] = $sessionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1368,6 +1402,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1424,6 +1459,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1485,6 +1521,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1549,6 +1586,7 @@ class Account extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1591,6 +1629,7 @@ class Account extends Service
         $apiParams['phone'] = $phone;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1641,6 +1680,7 @@ class Account extends Service
         $apiParams['url'] = $url;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1694,6 +1734,7 @@ class Account extends Service
         $apiParams['url'] = $url;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1735,6 +1776,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1779,6 +1821,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1820,6 +1863,7 @@ class Account extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1861,6 +1905,7 @@ class Account extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Activities.php
+++ b/src/Appwrite/Services/Activities.php
@@ -36,6 +36,7 @@ class Activities extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -72,6 +73,7 @@ class Activities extends Service
         $apiParams['eventId'] = $eventId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Advisor.php
+++ b/src/Appwrite/Services/Advisor.php
@@ -43,6 +43,7 @@ class Advisor extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -80,6 +81,7 @@ class Advisor extends Service
         $apiParams['reportId'] = $reportId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -117,6 +119,7 @@ class Advisor extends Service
         $apiParams['reportId'] = $reportId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -161,6 +164,7 @@ class Advisor extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -199,6 +203,7 @@ class Advisor extends Service
         $apiParams['insightId'] = $insightId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Avatars.php
+++ b/src/Appwrite/Services/Avatars.php
@@ -64,6 +64,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -118,6 +119,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -152,6 +154,7 @@ class Avatars extends Service
         $apiParams['url'] = $url;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -207,6 +210,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -258,6 +262,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -322,6 +327,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -370,6 +376,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -505,6 +512,7 @@ class Avatars extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Backups.php
+++ b/src/Appwrite/Services/Backups.php
@@ -37,6 +37,7 @@ class Backups extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -74,6 +75,7 @@ class Backups extends Service
         $apiParams['resourceId'] = $resourceId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -110,6 +112,7 @@ class Backups extends Service
         $apiParams['archiveId'] = $archiveId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -145,6 +148,7 @@ class Backups extends Service
         $apiParams['archiveId'] = $archiveId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -180,6 +184,7 @@ class Backups extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -233,6 +238,7 @@ class Backups extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -269,6 +275,7 @@ class Backups extends Service
         $apiParams['policyId'] = $policyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -315,6 +322,7 @@ class Backups extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -351,6 +359,7 @@ class Backups extends Service
         $apiParams['policyId'] = $policyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -395,6 +404,7 @@ class Backups extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -434,6 +444,7 @@ class Backups extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -469,6 +480,7 @@ class Backups extends Service
         $apiParams['restorationId'] = $restorationId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Databases.php
+++ b/src/Appwrite/Services/Databases.php
@@ -54,6 +54,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -100,6 +101,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -139,6 +141,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -177,6 +180,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -213,6 +217,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -258,6 +263,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -294,6 +300,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -331,6 +338,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -371,6 +379,7 @@ class Databases extends Service
         $apiParams['databaseId'] = $databaseId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -419,6 +428,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -459,6 +469,7 @@ class Databases extends Service
         $apiParams['databaseId'] = $databaseId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -510,6 +521,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -577,6 +589,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -619,6 +632,7 @@ class Databases extends Service
         $apiParams['collectionId'] = $collectionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -681,6 +695,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -723,6 +738,7 @@ class Databases extends Service
         $apiParams['collectionId'] = $collectionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -770,6 +786,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -827,6 +844,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -882,6 +900,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -935,6 +954,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -985,6 +1005,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1037,6 +1058,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1087,6 +1109,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1140,6 +1163,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1191,6 +1215,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1247,6 +1272,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1300,6 +1326,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1358,6 +1385,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1413,6 +1441,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1471,6 +1500,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1526,6 +1556,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1579,6 +1610,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1630,6 +1662,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1677,6 +1710,7 @@ class Databases extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1727,6 +1761,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1782,6 +1817,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1830,6 +1866,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1885,6 +1922,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1933,6 +1971,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1980,6 +2019,7 @@ class Databases extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2030,6 +2070,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2077,6 +2118,7 @@ class Databases extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2127,6 +2169,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2188,6 +2231,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2240,6 +2284,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2300,6 +2345,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2353,6 +2399,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2408,6 +2455,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2456,6 +2504,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2509,6 +2558,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2560,6 +2610,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2617,6 +2668,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2667,6 +2719,7 @@ class Databases extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2710,6 +2763,7 @@ class Databases extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2792,6 +2846,7 @@ class Databases extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2850,6 +2905,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2901,6 +2957,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2949,6 +3006,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2998,6 +3056,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3053,6 +3112,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3102,6 +3162,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3156,6 +3217,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3210,6 +3272,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3263,6 +3326,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3308,6 +3372,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3358,6 +3423,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3412,6 +3478,7 @@ class Databases extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3463,6 +3530,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3521,6 +3589,7 @@ class Databases extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3564,6 +3633,7 @@ class Databases extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3606,6 +3676,7 @@ class Databases extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Functions.php
+++ b/src/Appwrite/Services/Functions.php
@@ -53,6 +53,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -190,6 +191,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -224,6 +226,7 @@ class Functions extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -257,6 +260,7 @@ class Functions extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -292,6 +296,7 @@ class Functions extends Service
         $apiParams['functionId'] = $functionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -420,6 +425,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -456,6 +462,7 @@ class Functions extends Service
         $apiParams['functionId'] = $functionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -491,6 +498,7 @@ class Functions extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -543,6 +551,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -601,6 +610,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'multipart/form-data';
         $size = 0;
         $mimeType = null;
@@ -642,7 +652,10 @@ class Functions extends Service
         $counter = 0;
 
 
-        $apiHeaders = ['content-type' => 'multipart/form-data'];
+        $apiHeaders = [
+            'content-type' => 'multipart/form-data',
+            'X-Appwrite-Project' => $this->client->getConfig('project'),
+        ];
         $handle = null;
 
         if(!empty($code->getPath())) {
@@ -879,6 +892,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -934,6 +948,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -981,6 +996,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1019,6 +1035,7 @@ class Functions extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1056,6 +1073,7 @@ class Functions extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1097,6 +1115,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1134,6 +1153,7 @@ class Functions extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1181,6 +1201,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1246,6 +1267,7 @@ class Functions extends Service
         $apiParams['scheduledAt'] = $scheduledAt;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1284,6 +1306,7 @@ class Functions extends Service
         $apiParams['executionId'] = $executionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1321,6 +1344,7 @@ class Functions extends Service
         $apiParams['executionId'] = $executionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1363,6 +1387,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1410,6 +1435,7 @@ class Functions extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1448,6 +1474,7 @@ class Functions extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1491,6 +1518,7 @@ class Functions extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1529,6 +1557,7 @@ class Functions extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Graphql.php
+++ b/src/Appwrite/Services/Graphql.php
@@ -33,6 +33,7 @@ class Graphql extends Service
         $apiParams['query'] = $query;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['x-sdk-graphql'] = 'true';
         $apiHeaders['content-type'] = 'application/json';
 
@@ -66,6 +67,7 @@ class Graphql extends Service
         $apiParams['query'] = $query;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['x-sdk-graphql'] = 'true';
         $apiHeaders['content-type'] = 'application/json';
 

--- a/src/Appwrite/Services/Health.php
+++ b/src/Appwrite/Services/Health.php
@@ -32,6 +32,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -65,6 +66,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -78,6 +80,43 @@ class Health extends Service
         }
 
         return \Appwrite\Models\HealthAntivirus::from($response);
+
+    }
+
+    /**
+     * Check the database that backs the audit and activity store. When the
+     * connection is reachable the endpoint returns a passing status with its
+     * response time.
+     * 
+     *
+     * @throws AppwriteException
+     * @return \Appwrite\Models\HealthStatusList
+     */
+    public function getAuditsDB(): \Appwrite\Models\HealthStatusList
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/health/audits-db'
+        );
+
+        $apiParams = [];
+
+        $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
+
+        $response = $this->client->call(
+            Client::METHOD_GET,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\HealthStatusList::from($response);
 
     }
 
@@ -99,6 +138,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -137,6 +177,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -182,6 +223,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -215,6 +257,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -248,6 +291,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -288,6 +332,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -327,6 +372,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -367,6 +413,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -411,6 +458,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -450,6 +498,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -491,6 +540,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -530,6 +580,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -569,6 +620,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -608,6 +660,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -647,6 +700,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -686,6 +740,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -725,6 +780,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -764,6 +820,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -803,6 +860,7 @@ class Health extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -836,6 +894,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -869,6 +928,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -908,6 +968,7 @@ class Health extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Locale.php
+++ b/src/Appwrite/Services/Locale.php
@@ -36,6 +36,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -70,6 +71,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -104,6 +106,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -138,6 +141,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -172,6 +176,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -206,6 +211,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -241,6 +247,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -275,6 +282,7 @@ class Locale extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Messaging.php
+++ b/src/Appwrite/Services/Messaging.php
@@ -48,6 +48,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -129,6 +130,7 @@ class Messaging extends Service
         $apiParams['scheduledAt'] = $scheduledAt;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -190,6 +192,7 @@ class Messaging extends Service
         $apiParams['attachments'] = $attachments;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -310,6 +313,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -385,6 +389,7 @@ class Messaging extends Service
         $apiParams['priority'] = $priority;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -445,6 +450,7 @@ class Messaging extends Service
         $apiParams['scheduledAt'] = $scheduledAt;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -496,6 +502,7 @@ class Messaging extends Service
         $apiParams['scheduledAt'] = $scheduledAt;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -533,6 +540,7 @@ class Messaging extends Service
         $apiParams['messageId'] = $messageId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -569,6 +577,7 @@ class Messaging extends Service
         $apiParams['messageId'] = $messageId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -611,6 +620,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -656,6 +666,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -704,6 +715,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -768,6 +780,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -833,6 +846,7 @@ class Messaging extends Service
         $apiParams['sandbox'] = $sandbox;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -875,6 +889,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -920,6 +935,7 @@ class Messaging extends Service
         $apiParams['serviceAccountJSON'] = $serviceAccountJSON;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -992,6 +1008,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1067,6 +1084,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1122,6 +1140,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1180,6 +1199,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1245,6 +1265,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1313,6 +1334,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1378,6 +1400,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1446,6 +1469,162 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Provider::from($response);
+
+    }
+
+    /**
+     * Create a new Amazon SES provider.
+     *
+     * @param string $providerId
+     * @param string $name
+     * @param ?string $accessKey
+     * @param ?string $secretKey
+     * @param ?string $region
+     * @param ?string $fromName
+     * @param ?string $fromEmail
+     * @param ?string $replyToName
+     * @param ?string $replyToEmail
+     * @param ?bool $enabled
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Provider
+     */
+    public function createSesProvider(string $providerId, string $name, ?string $accessKey = null, ?string $secretKey = null, ?string $region = null, ?string $fromName = null, ?string $fromEmail = null, ?string $replyToName = null, ?string $replyToEmail = null, ?bool $enabled = null): \Appwrite\Models\Provider
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/messaging/providers/ses'
+        );
+
+        $apiParams = [];
+        $apiParams['providerId'] = $providerId;
+        $apiParams['name'] = $name;
+
+        if (!is_null($accessKey)) {
+            $apiParams['accessKey'] = $accessKey;
+        }
+
+        if (!is_null($secretKey)) {
+            $apiParams['secretKey'] = $secretKey;
+        }
+
+        if (!is_null($region)) {
+            $apiParams['region'] = $region;
+        }
+
+        if (!is_null($fromName)) {
+            $apiParams['fromName'] = $fromName;
+        }
+
+        if (!is_null($fromEmail)) {
+            $apiParams['fromEmail'] = $fromEmail;
+        }
+
+        if (!is_null($replyToName)) {
+            $apiParams['replyToName'] = $replyToName;
+        }
+
+        if (!is_null($replyToEmail)) {
+            $apiParams['replyToEmail'] = $replyToEmail;
+        }
+        $apiParams['enabled'] = $enabled;
+
+        $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_POST,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Provider::from($response);
+
+    }
+
+    /**
+     * Update an Amazon SES provider by its unique ID.
+     *
+     * @param string $providerId
+     * @param ?string $name
+     * @param ?bool $enabled
+     * @param ?string $accessKey
+     * @param ?string $secretKey
+     * @param ?string $region
+     * @param ?string $fromName
+     * @param ?string $fromEmail
+     * @param ?string $replyToName
+     * @param ?string $replyToEmail
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Provider
+     */
+    public function updateSesProvider(string $providerId, ?string $name = null, ?bool $enabled = null, ?string $accessKey = null, ?string $secretKey = null, ?string $region = null, ?string $fromName = null, ?string $fromEmail = null, ?string $replyToName = null, ?string $replyToEmail = null): \Appwrite\Models\Provider
+    {
+        $apiPath = str_replace(
+            ['{providerId}'],
+            [$providerId],
+            '/messaging/providers/ses/{providerId}'
+        );
+
+        $apiParams = [];
+        $apiParams['providerId'] = $providerId;
+
+        if (!is_null($name)) {
+            $apiParams['name'] = $name;
+        }
+        $apiParams['enabled'] = $enabled;
+
+        if (!is_null($accessKey)) {
+            $apiParams['accessKey'] = $accessKey;
+        }
+
+        if (!is_null($secretKey)) {
+            $apiParams['secretKey'] = $secretKey;
+        }
+
+        if (!is_null($region)) {
+            $apiParams['region'] = $region;
+        }
+
+        if (!is_null($fromName)) {
+            $apiParams['fromName'] = $fromName;
+        }
+
+        if (!is_null($fromEmail)) {
+            $apiParams['fromEmail'] = $fromEmail;
+        }
+
+        if (!is_null($replyToName)) {
+            $apiParams['replyToName'] = $replyToName;
+        }
+
+        if (!is_null($replyToEmail)) {
+            $apiParams['replyToEmail'] = $replyToEmail;
+        }
+
+        $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1538,6 +1717,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1630,6 +1810,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1685,6 +1866,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1743,6 +1925,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1798,6 +1981,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1856,6 +2040,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1911,6 +2096,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1969,6 +2155,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2024,6 +2211,7 @@ class Messaging extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2082,6 +2270,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2119,6 +2308,7 @@ class Messaging extends Service
         $apiParams['providerId'] = $providerId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2154,6 +2344,7 @@ class Messaging extends Service
         $apiParams['providerId'] = $providerId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2196,6 +2387,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2241,6 +2433,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2289,6 +2482,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2331,6 +2525,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2368,6 +2563,7 @@ class Messaging extends Service
         $apiParams['topicId'] = $topicId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2408,6 +2604,7 @@ class Messaging extends Service
         $apiParams['subscribe'] = $subscribe;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2444,6 +2641,7 @@ class Messaging extends Service
         $apiParams['topicId'] = $topicId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2486,6 +2684,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2536,6 +2735,7 @@ class Messaging extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2575,6 +2775,7 @@ class Messaging extends Service
         $apiParams['targetId'] = $targetId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2614,6 +2815,7 @@ class Messaging extends Service
         $apiParams['subscriberId'] = $subscriberId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2651,6 +2853,7 @@ class Messaging extends Service
         $apiParams['subscriberId'] = $subscriberId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Organization.php
+++ b/src/Appwrite/Services/Organization.php
@@ -43,6 +43,7 @@ class Organization extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -84,6 +85,7 @@ class Organization extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -121,6 +123,7 @@ class Organization extends Service
         $apiParams['keyId'] = $keyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -163,6 +166,7 @@ class Organization extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -200,6 +204,7 @@ class Organization extends Service
         $apiParams['keyId'] = $keyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -246,6 +251,7 @@ class Organization extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -288,6 +294,7 @@ class Organization extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -324,6 +331,7 @@ class Organization extends Service
         $apiParams['projectId'] = $projectId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -361,6 +369,7 @@ class Organization extends Service
         $apiParams['name'] = $name;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -397,6 +406,7 @@ class Organization extends Service
         $apiParams['projectId'] = $projectId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Presences.php
+++ b/src/Appwrite/Services/Presences.php
@@ -47,6 +47,7 @@ class Presences extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -84,6 +85,7 @@ class Presences extends Service
         $apiParams['presenceId'] = $presenceId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -139,6 +141,7 @@ class Presences extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -204,6 +207,7 @@ class Presences extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -241,6 +245,7 @@ class Presences extends Service
         $apiParams['presenceId'] = $presenceId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Project.php
+++ b/src/Appwrite/Services/Project.php
@@ -41,6 +41,7 @@ class Project extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -74,6 +75,7 @@ class Project extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -109,6 +111,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -153,6 +156,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -198,6 +202,7 @@ class Project extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -240,6 +245,7 @@ class Project extends Service
         $apiParams['duration'] = $duration;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -276,6 +282,7 @@ class Project extends Service
         $apiParams['keyId'] = $keyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -318,6 +325,7 @@ class Project extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -355,6 +363,7 @@ class Project extends Service
         $apiParams['keyId'] = $keyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -388,6 +397,7 @@ class Project extends Service
         $apiParams['labels'] = $labels;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -433,6 +443,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -471,6 +482,7 @@ class Project extends Service
         $apiParams['otp'] = $otp;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -508,6 +520,7 @@ class Project extends Service
         $apiParams['number'] = $number;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -546,6 +559,7 @@ class Project extends Service
         $apiParams['otp'] = $otp;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -583,6 +597,7 @@ class Project extends Service
         $apiParams['number'] = $number;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -625,6 +640,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -638,6 +654,60 @@ class Project extends Service
         }
 
         return \Appwrite\Models\OAuth2ProviderList::from($response);
+
+    }
+
+    /**
+     * Update the OAuth2 server (OIDC provider) configuration.
+     *
+     * @param bool $enabled
+     * @param string $authorizationUrl
+     * @param ?array $scopes
+     * @param ?int $accessTokenDuration
+     * @param ?int $refreshTokenDuration
+     * @param ?int $publicAccessTokenDuration
+     * @param ?int $publicRefreshTokenDuration
+     * @param ?bool $confidentialPkce
+     * @throws AppwriteException
+     * @return \Appwrite\Models\Project
+     */
+    public function updateOAuth2Server(bool $enabled, string $authorizationUrl, ?array $scopes = null, ?int $accessTokenDuration = null, ?int $refreshTokenDuration = null, ?int $publicAccessTokenDuration = null, ?int $publicRefreshTokenDuration = null, ?bool $confidentialPkce = null): \Appwrite\Models\Project
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/project/oauth2-server'
+        );
+
+        $apiParams = [];
+        $apiParams['enabled'] = $enabled;
+        $apiParams['authorizationUrl'] = $authorizationUrl;
+
+        if (!is_null($scopes)) {
+            $apiParams['scopes'] = $scopes;
+        }
+        $apiParams['accessTokenDuration'] = $accessTokenDuration;
+        $apiParams['refreshTokenDuration'] = $refreshTokenDuration;
+        $apiParams['publicAccessTokenDuration'] = $publicAccessTokenDuration;
+        $apiParams['publicRefreshTokenDuration'] = $publicRefreshTokenDuration;
+        $apiParams['confidentialPkce'] = $confidentialPkce;
+
+        $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PUT,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\Project::from($response);
 
     }
 
@@ -664,6 +734,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -708,6 +779,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -750,6 +822,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -792,6 +865,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -832,6 +906,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -872,6 +947,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -912,6 +988,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -952,6 +1029,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -992,6 +1070,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1032,6 +1111,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1072,6 +1152,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1112,6 +1193,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1152,6 +1234,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1192,6 +1275,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1232,6 +1316,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1274,6 +1359,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1314,6 +1400,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1356,6 +1443,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1398,6 +1486,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1442,6 +1531,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1482,6 +1572,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1522,6 +1613,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1564,6 +1656,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1604,6 +1697,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1652,6 +1746,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1696,6 +1791,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1736,6 +1832,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1776,6 +1873,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1816,6 +1914,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1856,6 +1955,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1896,6 +1996,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1936,6 +2037,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1976,6 +2078,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2016,6 +2119,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2056,6 +2160,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2096,6 +2201,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2136,6 +2242,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2176,6 +2283,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2216,6 +2324,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2256,6 +2365,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2296,6 +2406,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2336,6 +2447,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2373,6 +2485,7 @@ class Project extends Service
         $apiParams['providerId'] = $providerId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2577,6 +2690,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2618,6 +2732,7 @@ class Project extends Service
         $apiParams['applicationId'] = $applicationId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2659,6 +2774,7 @@ class Project extends Service
         $apiParams['applicationId'] = $applicationId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2701,6 +2817,7 @@ class Project extends Service
         $apiParams['bundleIdentifier'] = $bundleIdentifier;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2742,6 +2859,7 @@ class Project extends Service
         $apiParams['bundleIdentifier'] = $bundleIdentifier;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2784,6 +2902,7 @@ class Project extends Service
         $apiParams['packageName'] = $packageName;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2825,6 +2944,7 @@ class Project extends Service
         $apiParams['packageName'] = $packageName;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2867,6 +2987,7 @@ class Project extends Service
         $apiParams['hostname'] = $hostname;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2908,6 +3029,7 @@ class Project extends Service
         $apiParams['hostname'] = $hostname;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2950,6 +3072,7 @@ class Project extends Service
         $apiParams['packageIdentifierName'] = $packageIdentifierName;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2991,6 +3114,7 @@ class Project extends Service
         $apiParams['packageIdentifierName'] = $packageIdentifierName;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3028,6 +3152,7 @@ class Project extends Service
         $apiParams['platformId'] = $platformId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3084,6 +3209,7 @@ class Project extends Service
         $apiParams['platformId'] = $platformId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3124,6 +3250,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3160,6 +3287,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3197,6 +3325,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3234,6 +3363,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3295,6 +3425,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3333,6 +3464,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3377,6 +3509,7 @@ class Project extends Service
         $apiParams['total'] = $total;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3416,6 +3549,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3430,6 +3564,66 @@ class Project extends Service
         }
 
         return \Appwrite\Models\Project::from($response);
+
+    }
+
+    /**
+     * Update the password strength requirements for users in the project.
+     *
+     * @param ?int $min
+     * @param ?bool $uppercase
+     * @param ?bool $lowercase
+     * @param ?bool $number
+     * @param ?bool $symbols
+     * @throws AppwriteException
+     * @return \Appwrite\Models\PolicyPasswordStrength
+     */
+    public function updatePasswordStrengthPolicy(?int $min = null, ?bool $uppercase = null, ?bool $lowercase = null, ?bool $number = null, ?bool $symbols = null): \Appwrite\Models\PolicyPasswordStrength
+    {
+        $apiPath = str_replace(
+            [],
+            [],
+            '/project/policies/password-strength'
+        );
+
+        $apiParams = [];
+
+        if (!is_null($min)) {
+            $apiParams['min'] = $min;
+        }
+
+        if (!is_null($uppercase)) {
+            $apiParams['uppercase'] = $uppercase;
+        }
+
+        if (!is_null($lowercase)) {
+            $apiParams['lowercase'] = $lowercase;
+        }
+
+        if (!is_null($number)) {
+            $apiParams['number'] = $number;
+        }
+
+        if (!is_null($symbols)) {
+            $apiParams['symbols'] = $symbols;
+        }
+
+        $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
+        $apiHeaders['content-type'] = 'application/json';
+
+        $response = $this->client->call(
+            Client::METHOD_PATCH,
+            $apiPath,
+            $apiHeaders,
+            $apiParams
+        );
+
+        if (!is_array($response)) {
+            throw new \UnexpectedValueException('Expected array response when hydrating a response model.');
+        }
+
+        return \Appwrite\Models\PolicyPasswordStrength::from($response);
 
     }
 
@@ -3456,6 +3650,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3493,6 +3688,7 @@ class Project extends Service
         $apiParams['duration'] = $duration;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3531,6 +3727,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3568,6 +3765,7 @@ class Project extends Service
         $apiParams['total'] = $total;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3606,6 +3804,7 @@ class Project extends Service
         $apiParams['total'] = $total;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3629,9 +3828,9 @@ class Project extends Service
      *
      * @param ProjectPolicyId $policyId
      * @throws AppwriteException
-     * @return \Appwrite\Models\PolicyPasswordDictionary|\Appwrite\Models\PolicyPasswordHistory|\Appwrite\Models\PolicyPasswordPersonalData|\Appwrite\Models\PolicySessionAlert|\Appwrite\Models\PolicySessionDuration|\Appwrite\Models\PolicySessionInvalidation|\Appwrite\Models\PolicySessionLimit|\Appwrite\Models\PolicyUserLimit|\Appwrite\Models\PolicyMembershipPrivacy|\Appwrite\Models\PolicyDenyAliasedEmail|\Appwrite\Models\PolicyDenyDisposableEmail|\Appwrite\Models\PolicyDenyFreeEmail
+     * @return \Appwrite\Models\PolicyPasswordDictionary|\Appwrite\Models\PolicyPasswordHistory|\Appwrite\Models\PolicyPasswordStrength|\Appwrite\Models\PolicyPasswordPersonalData|\Appwrite\Models\PolicySessionAlert|\Appwrite\Models\PolicySessionDuration|\Appwrite\Models\PolicySessionInvalidation|\Appwrite\Models\PolicySessionLimit|\Appwrite\Models\PolicyUserLimit|\Appwrite\Models\PolicyMembershipPrivacy|\Appwrite\Models\PolicyDenyAliasedEmail|\Appwrite\Models\PolicyDenyDisposableEmail|\Appwrite\Models\PolicyDenyFreeEmail
      */
-    public function getPolicy(ProjectPolicyId $policyId): \Appwrite\Models\PolicyPasswordDictionary|\Appwrite\Models\PolicyPasswordHistory|\Appwrite\Models\PolicyPasswordPersonalData|\Appwrite\Models\PolicySessionAlert|\Appwrite\Models\PolicySessionDuration|\Appwrite\Models\PolicySessionInvalidation|\Appwrite\Models\PolicySessionLimit|\Appwrite\Models\PolicyUserLimit|\Appwrite\Models\PolicyMembershipPrivacy|\Appwrite\Models\PolicyDenyAliasedEmail|\Appwrite\Models\PolicyDenyDisposableEmail|\Appwrite\Models\PolicyDenyFreeEmail
+    public function getPolicy(ProjectPolicyId $policyId): \Appwrite\Models\PolicyPasswordDictionary|\Appwrite\Models\PolicyPasswordHistory|\Appwrite\Models\PolicyPasswordStrength|\Appwrite\Models\PolicyPasswordPersonalData|\Appwrite\Models\PolicySessionAlert|\Appwrite\Models\PolicySessionDuration|\Appwrite\Models\PolicySessionInvalidation|\Appwrite\Models\PolicySessionLimit|\Appwrite\Models\PolicyUserLimit|\Appwrite\Models\PolicyMembershipPrivacy|\Appwrite\Models\PolicyDenyAliasedEmail|\Appwrite\Models\PolicyDenyDisposableEmail|\Appwrite\Models\PolicyDenyFreeEmail
     {
         $apiPath = str_replace(
             ['{policyId}'],
@@ -3643,6 +3842,7 @@ class Project extends Service
         $apiParams['policyId'] = $policyId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3661,6 +3861,10 @@ class Project extends Service
 
         if (($response['$id'] ?? null) === 'password-history') {
             return \Appwrite\Models\PolicyPasswordHistory::from($response);
+        }
+
+        if (($response['$id'] ?? null) === 'password-strength') {
+            return \Appwrite\Models\PolicyPasswordStrength::from($response);
         }
 
         if (($response['$id'] ?? null) === 'password-personal-data') {
@@ -3729,6 +3933,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3768,6 +3973,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3824,6 +4030,7 @@ class Project extends Service
         $apiParams['enabled'] = $enabled;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3860,6 +4067,7 @@ class Project extends Service
         $apiParams['emails'] = $emails;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3902,6 +4110,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3955,6 +4164,7 @@ class Project extends Service
         $apiParams['replyToName'] = $replyToName;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3998,6 +4208,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -4041,6 +4252,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -4086,6 +4298,7 @@ class Project extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -4122,6 +4335,7 @@ class Project extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -4163,6 +4377,7 @@ class Project extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -4199,6 +4414,7 @@ class Project extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Proxy.php
+++ b/src/Appwrite/Services/Proxy.php
@@ -44,6 +44,7 @@ class Proxy extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -82,6 +83,7 @@ class Proxy extends Service
         $apiParams['domain'] = $domain;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -128,6 +130,7 @@ class Proxy extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -176,6 +179,7 @@ class Proxy extends Service
         $apiParams['resourceType'] = $resourceType;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -222,6 +226,7 @@ class Proxy extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -258,6 +263,7 @@ class Proxy extends Service
         $apiParams['ruleId'] = $ruleId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -293,6 +299,7 @@ class Proxy extends Service
         $apiParams['ruleId'] = $ruleId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -328,6 +335,7 @@ class Proxy extends Service
         $apiParams['ruleId'] = $ruleId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Sites.php
+++ b/src/Appwrite/Services/Sites.php
@@ -53,6 +53,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -189,6 +190,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -224,6 +226,7 @@ class Sites extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -257,6 +260,7 @@ class Sites extends Service
         $apiParams = [];
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -292,6 +296,7 @@ class Sites extends Service
         $apiParams['siteId'] = $siteId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -425,6 +430,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -461,6 +467,7 @@ class Sites extends Service
         $apiParams['siteId'] = $siteId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -496,6 +503,7 @@ class Sites extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -548,6 +556,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -607,6 +616,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'multipart/form-data';
         $size = 0;
         $mimeType = null;
@@ -648,7 +658,10 @@ class Sites extends Service
         $counter = 0;
 
 
-        $apiHeaders = ['content-type' => 'multipart/form-data'];
+        $apiHeaders = [
+            'content-type' => 'multipart/form-data',
+            'X-Appwrite-Project' => $this->client->getConfig('project'),
+        ];
         $handle = null;
 
         if(!empty($code->getPath())) {
@@ -880,6 +893,7 @@ class Sites extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -935,6 +949,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -982,6 +997,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1020,6 +1036,7 @@ class Sites extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1057,6 +1074,7 @@ class Sites extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1098,6 +1116,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1135,6 +1154,7 @@ class Sites extends Service
         $apiParams['deploymentId'] = $deploymentId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1182,6 +1202,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1219,6 +1240,7 @@ class Sites extends Service
         $apiParams['logId'] = $logId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1256,6 +1278,7 @@ class Sites extends Service
         $apiParams['logId'] = $logId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1298,6 +1321,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1345,6 +1369,7 @@ class Sites extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1383,6 +1408,7 @@ class Sites extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1426,6 +1452,7 @@ class Sites extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1464,6 +1491,7 @@ class Sites extends Service
         $apiParams['variableId'] = $variableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Storage.php
+++ b/src/Appwrite/Services/Storage.php
@@ -50,6 +50,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -129,6 +130,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -166,6 +168,7 @@ class Storage extends Service
         $apiParams['bucketId'] = $bucketId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -245,6 +248,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -281,6 +285,7 @@ class Storage extends Service
         $apiParams['bucketId'] = $bucketId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -329,6 +334,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -390,6 +396,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'multipart/form-data';
         $size = 0;
         $mimeType = null;
@@ -436,7 +443,10 @@ class Storage extends Service
         } catch(\Exception $e) {
         }
 
-        $apiHeaders = ['content-type' => 'multipart/form-data'];
+        $apiHeaders = [
+            'content-type' => 'multipart/form-data',
+            'X-Appwrite-Project' => $this->client->getConfig('project'),
+        ];
         $handle = null;
 
         if(!empty($file->getPath())) {
@@ -666,6 +676,7 @@ class Storage extends Service
         $apiParams['fileId'] = $fileId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -711,6 +722,7 @@ class Storage extends Service
         $apiParams['permissions'] = $permissions;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -750,6 +762,7 @@ class Storage extends Service
         $apiParams['fileId'] = $fileId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -791,6 +804,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -888,6 +902,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -928,6 +943,7 @@ class Storage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/TablesDB.php
+++ b/src/Appwrite/Services/TablesDB.php
@@ -51,6 +51,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -94,6 +95,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -133,6 +135,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -171,6 +174,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -207,6 +211,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -252,6 +257,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -288,6 +294,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -325,6 +332,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -362,6 +370,7 @@ class TablesDB extends Service
         $apiParams['databaseId'] = $databaseId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -407,6 +416,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -444,6 +454,7 @@ class TablesDB extends Service
         $apiParams['databaseId'] = $databaseId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -492,6 +503,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -556,6 +568,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -595,6 +608,7 @@ class TablesDB extends Service
         $apiParams['tableId'] = $tableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -654,6 +668,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -693,6 +708,7 @@ class TablesDB extends Service
         $apiParams['tableId'] = $tableId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -737,6 +753,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -791,6 +808,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -843,6 +861,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -893,6 +912,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -940,6 +960,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -989,6 +1010,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1036,6 +1058,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1086,6 +1109,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1134,6 +1158,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1186,6 +1211,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1236,6 +1262,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1291,6 +1318,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1343,6 +1371,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1398,6 +1427,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1450,6 +1480,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1500,6 +1531,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1548,6 +1580,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1592,6 +1625,7 @@ class TablesDB extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1639,6 +1673,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1694,6 +1729,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1742,6 +1778,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1797,6 +1834,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1845,6 +1883,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1889,6 +1928,7 @@ class TablesDB extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1936,6 +1976,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1980,6 +2021,7 @@ class TablesDB extends Service
         $apiParams['default'] = $xdefault;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2027,6 +2069,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2085,6 +2128,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2145,6 +2189,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2198,6 +2243,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2253,6 +2299,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2301,6 +2348,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2351,6 +2399,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2399,6 +2448,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2456,6 +2506,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2506,6 +2557,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2546,6 +2598,7 @@ class TablesDB extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2625,6 +2678,7 @@ class TablesDB extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2667,6 +2721,7 @@ class TablesDB extends Service
         $apiParams['newKey'] = $newKey;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2715,6 +2770,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2770,6 +2826,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2810,6 +2867,7 @@ class TablesDB extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2849,6 +2907,7 @@ class TablesDB extends Service
         $apiParams['key'] = $key;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2904,6 +2963,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -2952,6 +3012,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -2997,6 +3058,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3043,6 +3105,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3094,6 +3157,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3140,6 +3204,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3191,6 +3256,7 @@ class TablesDB extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -3242,6 +3308,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3292,6 +3359,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3334,6 +3402,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3381,6 +3450,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -3432,6 +3502,7 @@ class TablesDB extends Service
         $apiParams['transactionId'] = $transactionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Teams.php
+++ b/src/Appwrite/Services/Teams.php
@@ -47,6 +47,7 @@ class Teams extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -91,6 +92,7 @@ class Teams extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -127,6 +129,7 @@ class Teams extends Service
         $apiParams['teamId'] = $teamId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -164,6 +167,7 @@ class Teams extends Service
         $apiParams['name'] = $name;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -201,6 +205,7 @@ class Teams extends Service
         $apiParams['teamId'] = $teamId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -250,6 +255,7 @@ class Teams extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -332,6 +338,7 @@ class Teams extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -372,6 +379,7 @@ class Teams extends Service
         $apiParams['membershipId'] = $membershipId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -414,6 +422,7 @@ class Teams extends Service
         $apiParams['roles'] = $roles;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -454,6 +463,7 @@ class Teams extends Service
         $apiParams['membershipId'] = $membershipId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -498,6 +508,7 @@ class Teams extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -536,6 +547,7 @@ class Teams extends Service
         $apiParams['teamId'] = $teamId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -575,6 +587,7 @@ class Teams extends Service
         $apiParams['prefs'] = $prefs;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Tokens.php
+++ b/src/Appwrite/Services/Tokens.php
@@ -46,6 +46,7 @@ class Tokens extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -86,6 +87,7 @@ class Tokens extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -122,6 +124,7 @@ class Tokens extends Service
         $apiParams['tokenId'] = $tokenId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -160,6 +163,7 @@ class Tokens extends Service
         $apiParams['expire'] = $expire;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -196,6 +200,7 @@ class Tokens extends Service
         $apiParams['tokenId'] = $tokenId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Usage.php
+++ b/src/Appwrite/Services/Usage.php
@@ -52,6 +52,7 @@ class Usage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -105,6 +106,7 @@ class Usage extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,

--- a/src/Appwrite/Services/Users.php
+++ b/src/Appwrite/Services/Users.php
@@ -50,6 +50,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -99,6 +100,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -147,6 +149,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -195,6 +198,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -244,6 +248,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -279,6 +284,7 @@ class Users extends Service
         $apiParams['identityId'] = $identityId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -323,6 +329,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -371,6 +378,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -429,6 +437,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -484,6 +493,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -537,6 +547,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -573,6 +584,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -613,6 +625,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -647,6 +660,7 @@ class Users extends Service
         $apiParams['email'] = $email;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -690,6 +704,7 @@ class Users extends Service
         $apiParams['impersonator'] = $impersonator;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -738,6 +753,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -781,6 +797,7 @@ class Users extends Service
         $apiParams['labels'] = $labels;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -827,6 +844,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -877,6 +895,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -914,6 +933,7 @@ class Users extends Service
         $apiParams['mfa'] = $mfa;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -952,6 +972,7 @@ class Users extends Service
         $apiParams['type'] = $type;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -984,6 +1005,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1022,6 +1044,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1060,6 +1083,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1099,6 +1123,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1137,6 +1162,7 @@ class Users extends Service
         $apiParams['name'] = $name;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1175,6 +1201,7 @@ class Users extends Service
         $apiParams['password'] = $password;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1213,6 +1240,7 @@ class Users extends Service
         $apiParams['number'] = $number;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1249,6 +1277,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1288,6 +1317,7 @@ class Users extends Service
         $apiParams['prefs'] = $prefs;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1329,6 +1359,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1369,6 +1400,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1405,6 +1437,7 @@ class Users extends Service
         $apiParams['userId'] = $userId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1439,6 +1472,7 @@ class Users extends Service
         $apiParams['sessionId'] = $sessionId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1474,6 +1508,7 @@ class Users extends Service
         $apiParams['status'] = $status;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1520,6 +1555,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1571,6 +1607,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1609,6 +1646,7 @@ class Users extends Service
         $apiParams['targetId'] = $targetId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -1661,6 +1699,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1699,6 +1738,7 @@ class Users extends Service
         $apiParams['targetId'] = $targetId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1745,6 +1785,7 @@ class Users extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1783,6 +1824,7 @@ class Users extends Service
         $apiParams['emailVerification'] = $emailVerification;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -1821,6 +1863,7 @@ class Users extends Service
         $apiParams['phoneVerification'] = $phoneVerification;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/src/Appwrite/Services/Webhooks.php
+++ b/src/Appwrite/Services/Webhooks.php
@@ -42,6 +42,7 @@ class Webhooks extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -106,6 +107,7 @@ class Webhooks extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -143,6 +145,7 @@ class Webhooks extends Service
         $apiParams['webhookId'] = $webhookId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
 
         $response = $this->client->call(
             Client::METHOD_GET,
@@ -205,6 +208,7 @@ class Webhooks extends Service
         }
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -242,6 +246,7 @@ class Webhooks extends Service
         $apiParams['webhookId'] = $webhookId;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(
@@ -278,6 +283,7 @@ class Webhooks extends Service
         $apiParams['secret'] = $secret;
 
         $apiHeaders = [];
+        $apiHeaders['X-Appwrite-Project'] = $this->client->getConfig('project');
         $apiHeaders['content-type'] = 'application/json';
 
         $response = $this->client->call(

--- a/tests/Appwrite/Services/AccountTest.php
+++ b/tests/Appwrite/Services/AccountTest.php
@@ -56,6 +56,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->get();
 
@@ -97,6 +100,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->create(
             "<USER_ID>",
@@ -142,6 +148,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateEmail(
             "email@example.com",
@@ -174,6 +183,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->listIdentities();
 
@@ -187,6 +199,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->deleteIdentity(
             "<IDENTITY_ID>"
@@ -204,6 +219,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createJWT();
 
@@ -245,6 +263,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->listLogs();
 
@@ -286,6 +307,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateMFA(
             true
@@ -304,6 +328,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createMFAAuthenticator(
             AuthenticatorType::TOTP()
@@ -347,6 +374,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateMFAAuthenticator(
             AuthenticatorType::TOTP(),
@@ -363,6 +393,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->deleteMFAAuthenticator(
             AuthenticatorType::TOTP()
@@ -383,6 +416,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createMFAChallenge(
             AuthenticationFactor::EMAIL()
@@ -428,6 +464,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateMFAChallenge(
             "<CHALLENGE_ID>",
@@ -449,6 +488,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->listMFAFactors();
 
@@ -464,6 +506,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->getMFARecoveryCodes();
 
@@ -479,6 +524,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createMFARecoveryCodes();
 
@@ -494,6 +542,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateMFARecoveryCodes();
 
@@ -535,6 +586,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateName(
             "<NAME>"
@@ -578,6 +632,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updatePassword(
             ""
@@ -621,6 +678,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updatePhone(
             "+12065550100",
@@ -637,6 +697,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->getPrefs();
 
@@ -678,6 +741,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updatePrefs(
             array()
@@ -700,6 +766,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createRecovery(
             "email@example.com",
@@ -723,6 +792,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateRecovery(
             "<USER_ID>",
@@ -775,6 +847,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->listSessions();
 
@@ -788,6 +863,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->deleteSessions();
 
@@ -831,6 +909,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createAnonymousSession();
 
@@ -874,6 +955,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createEmailPasswordSession(
             "email@example.com",
@@ -920,6 +1004,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateMagicURLSession(
             "<USER_ID>",
@@ -966,6 +1053,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updatePhoneSession(
             "<USER_ID>",
@@ -1012,6 +1102,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createSession(
             "<USER_ID>",
@@ -1058,6 +1151,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->getSession(
             "<SESSION_ID>"
@@ -1103,6 +1199,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateSession(
             "<SESSION_ID>"
@@ -1118,6 +1217,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->deleteSession(
             "<SESSION_ID>"
@@ -1161,6 +1263,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateStatus();
 
@@ -1181,6 +1286,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createEmailToken(
             "<USER_ID>",
@@ -1204,6 +1312,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createMagicURLToken(
             "<USER_ID>",
@@ -1220,6 +1331,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createOAuth2Token(
             OAuthProvider::AMAZON()
@@ -1242,6 +1356,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createPhoneToken(
             "<USER_ID>",
@@ -1265,6 +1382,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createEmailVerification(
             "https://example.com"
@@ -1287,6 +1407,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createVerification(
             "https://example.com"
@@ -1309,6 +1432,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateEmailVerification(
             "<USER_ID>",
@@ -1332,6 +1458,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updateVerification(
             "<USER_ID>",
@@ -1355,6 +1484,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->createPhoneVerification();
 
@@ -1375,6 +1507,9 @@ final class AccountTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->account->updatePhoneVerification(
             "<USER_ID>",

--- a/tests/Appwrite/Services/ActivitiesTest.php
+++ b/tests/Appwrite/Services/ActivitiesTest.php
@@ -63,6 +63,9 @@ final class ActivitiesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->activities->listEvents();
 
@@ -109,6 +112,9 @@ final class ActivitiesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->activities->getEvent(
             "<EVENT_ID>"

--- a/tests/Appwrite/Services/AdvisorTest.php
+++ b/tests/Appwrite/Services/AdvisorTest.php
@@ -66,6 +66,9 @@ final class AdvisorTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->advisor->listReports();
 
@@ -115,6 +118,9 @@ final class AdvisorTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->advisor->getReport(
             "<REPORT_ID>"
@@ -130,6 +136,9 @@ final class AdvisorTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->advisor->deleteReport(
             "<REPORT_ID>"
@@ -172,6 +181,9 @@ final class AdvisorTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->advisor->listInsights(
             "<REPORT_ID>"
@@ -209,6 +221,9 @@ final class AdvisorTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->advisor->getInsight(
             "<REPORT_ID>",

--- a/tests/Appwrite/Services/AvatarsTest.php
+++ b/tests/Appwrite/Services/AvatarsTest.php
@@ -32,6 +32,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getBrowser(
             Browser::AVANTBROWSER()
@@ -47,6 +50,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getCreditCard(
             CreditCard::AMERICANEXPRESS()
@@ -62,6 +68,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getFavicon(
             "https://example.com"
@@ -77,6 +86,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getFlag(
             Flag::AFGHANISTAN()
@@ -92,6 +104,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getImage(
             "https://example.com"
@@ -107,6 +122,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getInitials();
 
@@ -120,6 +138,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getQR(
             "<TEXT>"
@@ -135,6 +156,9 @@ final class AvatarsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->avatars->getScreenshot(
             "https://example.com"

--- a/tests/Appwrite/Services/BackupsTest.php
+++ b/tests/Appwrite/Services/BackupsTest.php
@@ -42,6 +42,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->listArchives();
 
@@ -66,6 +69,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->createArchive(
             array(BackupServices::DATABASES())
@@ -92,6 +98,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->getArchive(
             "<ARCHIVE_ID>"
@@ -107,6 +116,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->deleteArchive(
             "<ARCHIVE_ID>"
@@ -137,6 +149,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->listPolicies();
 
@@ -160,6 +175,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->createPolicy(
             "<POLICY_ID>",
@@ -188,6 +206,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->getPolicy(
             "<POLICY_ID>"
@@ -213,6 +234,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->updatePolicy(
             "<POLICY_ID>"
@@ -228,6 +252,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->deletePolicy(
             "<POLICY_ID>"
@@ -255,6 +282,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->createRestoration(
             "<ARCHIVE_ID>",
@@ -288,6 +318,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->listRestorations();
 
@@ -313,6 +346,9 @@ final class BackupsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->backups->getRestoration(
             "<RESTORATION_ID>"

--- a/tests/Appwrite/Services/DatabasesTest.php
+++ b/tests/Appwrite/Services/DatabasesTest.php
@@ -68,6 +68,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->list();
 
@@ -115,6 +118,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->create(
             "<DATABASE_ID>",
@@ -143,6 +149,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->listTransactions();
 
@@ -163,6 +172,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createTransaction();
 
@@ -183,6 +195,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->getTransaction(
             "<TRANSACTION_ID>"
@@ -205,6 +220,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateTransaction(
             "<TRANSACTION_ID>"
@@ -220,6 +238,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteTransaction(
             "<TRANSACTION_ID>"
@@ -242,6 +263,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createOperations(
             "<TRANSACTION_ID>"
@@ -291,6 +315,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->get(
             "<DATABASE_ID>"
@@ -340,6 +367,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->update(
             "<DATABASE_ID>"
@@ -355,6 +385,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->delete(
             "<DATABASE_ID>"
@@ -400,6 +433,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->listCollections(
             "<DATABASE_ID>"
@@ -440,6 +476,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createCollection(
             "<DATABASE_ID>",
@@ -482,6 +521,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->getCollection(
             "<DATABASE_ID>",
@@ -523,6 +565,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateCollection(
             "<DATABASE_ID>",
@@ -539,6 +584,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteCollection(
             "<DATABASE_ID>",
@@ -558,6 +606,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->listAttributes(
             "<DATABASE_ID>",
@@ -582,6 +633,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createBigIntAttribute(
             "<DATABASE_ID>",
@@ -608,6 +662,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateBigIntAttribute(
             "<DATABASE_ID>",
@@ -635,6 +692,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createBooleanAttribute(
             "<DATABASE_ID>",
@@ -661,6 +721,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateBooleanAttribute(
             "<DATABASE_ID>",
@@ -689,6 +752,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createDatetimeAttribute(
             "<DATABASE_ID>",
@@ -716,6 +782,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateDatetimeAttribute(
             "<DATABASE_ID>",
@@ -744,6 +813,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createEmailAttribute(
             "<DATABASE_ID>",
@@ -771,6 +843,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateEmailAttribute(
             "<DATABASE_ID>",
@@ -800,6 +875,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createEnumAttribute(
             "<DATABASE_ID>",
@@ -829,6 +907,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateEnumAttribute(
             "<DATABASE_ID>",
@@ -857,6 +938,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createFloatAttribute(
             "<DATABASE_ID>",
@@ -883,6 +967,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateFloatAttribute(
             "<DATABASE_ID>",
@@ -910,6 +997,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createIntegerAttribute(
             "<DATABASE_ID>",
@@ -936,6 +1026,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateIntegerAttribute(
             "<DATABASE_ID>",
@@ -964,6 +1057,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createIpAttribute(
             "<DATABASE_ID>",
@@ -991,6 +1087,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateIpAttribute(
             "<DATABASE_ID>",
@@ -1018,6 +1117,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createLineAttribute(
             "<DATABASE_ID>",
@@ -1044,6 +1146,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateLineAttribute(
             "<DATABASE_ID>",
@@ -1070,6 +1175,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createLongtextAttribute(
             "<DATABASE_ID>",
@@ -1096,6 +1204,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateLongtextAttribute(
             "<DATABASE_ID>",
@@ -1123,6 +1234,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createMediumtextAttribute(
             "<DATABASE_ID>",
@@ -1149,6 +1263,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateMediumtextAttribute(
             "<DATABASE_ID>",
@@ -1176,6 +1293,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createPointAttribute(
             "<DATABASE_ID>",
@@ -1202,6 +1322,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updatePointAttribute(
             "<DATABASE_ID>",
@@ -1228,6 +1351,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createPolygonAttribute(
             "<DATABASE_ID>",
@@ -1254,6 +1380,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updatePolygonAttribute(
             "<DATABASE_ID>",
@@ -1286,6 +1415,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createRelationshipAttribute(
             "<DATABASE_ID>",
@@ -1318,6 +1450,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateRelationshipAttribute(
             "<DATABASE_ID>",
@@ -1344,6 +1479,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createStringAttribute(
             "<DATABASE_ID>",
@@ -1372,6 +1510,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateStringAttribute(
             "<DATABASE_ID>",
@@ -1399,6 +1540,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createTextAttribute(
             "<DATABASE_ID>",
@@ -1425,6 +1569,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateTextAttribute(
             "<DATABASE_ID>",
@@ -1453,6 +1600,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createUrlAttribute(
             "<DATABASE_ID>",
@@ -1480,6 +1630,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateUrlAttribute(
             "<DATABASE_ID>",
@@ -1508,6 +1661,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createVarcharAttribute(
             "<DATABASE_ID>",
@@ -1536,6 +1692,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateVarcharAttribute(
             "<DATABASE_ID>",
@@ -1569,6 +1728,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->getAttribute(
             "<DATABASE_ID>",
@@ -1586,6 +1748,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteAttribute(
             "<DATABASE_ID>",
@@ -1616,6 +1781,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->listDocuments(
             "<DATABASE_ID>",
@@ -1640,6 +1808,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createDocument(
             "<DATABASE_ID>",
@@ -1671,6 +1842,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createDocuments(
             "<DATABASE_ID>",
@@ -1701,6 +1875,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->upsertDocuments(
             "<DATABASE_ID>",
@@ -1731,6 +1908,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateDocuments(
             "<DATABASE_ID>",
@@ -1760,6 +1940,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteDocuments(
             "<DATABASE_ID>",
@@ -1784,6 +1967,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->getDocument(
             "<DATABASE_ID>",
@@ -1809,6 +1995,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->upsertDocument(
             "<DATABASE_ID>",
@@ -1834,6 +2023,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->updateDocument(
             "<DATABASE_ID>",
@@ -1851,6 +2043,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteDocument(
             "<DATABASE_ID>",
@@ -1876,6 +2071,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->decrementDocumentAttribute(
             "<DATABASE_ID>",
@@ -1902,6 +2100,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->incrementDocumentAttribute(
             "<DATABASE_ID>",
@@ -1935,6 +2136,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->listIndexes(
             "<DATABASE_ID>",
@@ -1961,6 +2165,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->createIndex(
             "<DATABASE_ID>",
@@ -1990,6 +2197,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->getIndex(
             "<DATABASE_ID>",
@@ -2007,6 +2217,9 @@ final class DatabasesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->databases->deleteIndex(
             "<DATABASE_ID>",

--- a/tests/Appwrite/Services/FunctionsTest.php
+++ b/tests/Appwrite/Services/FunctionsTest.php
@@ -80,6 +80,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->list();
 
@@ -137,6 +140,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->create(
             "<FUNCTION_ID>",
@@ -168,6 +174,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->listRuntimes();
 
@@ -191,6 +200,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->listSpecifications();
 
@@ -248,6 +260,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->get(
             "<FUNCTION_ID>"
@@ -307,6 +322,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->update(
             "<FUNCTION_ID>",
@@ -323,6 +341,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->delete(
             "<FUNCTION_ID>"
@@ -382,6 +403,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->updateFunctionDeployment(
             "<FUNCTION_ID>",
@@ -431,6 +455,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->listDeployments(
             "<FUNCTION_ID>"
@@ -474,6 +501,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createDeployment(
             "<FUNCTION_ID>",
@@ -519,6 +549,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createDuplicateDeployment(
             "<FUNCTION_ID>",
@@ -563,6 +596,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createTemplateDeployment(
             "<FUNCTION_ID>",
@@ -611,6 +647,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createVcsDeployment(
             "<FUNCTION_ID>",
@@ -656,6 +695,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->getDeployment(
             "<FUNCTION_ID>",
@@ -672,6 +714,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->deleteDeployment(
             "<FUNCTION_ID>",
@@ -688,6 +733,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->getDeploymentDownload(
             "<FUNCTION_ID>",
@@ -732,6 +780,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->updateDeploymentStatus(
             "<FUNCTION_ID>",
@@ -781,6 +832,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->listExecutions(
             "<FUNCTION_ID>"
@@ -824,6 +878,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createExecution(
             "<FUNCTION_ID>"
@@ -867,6 +924,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->getExecution(
             "<FUNCTION_ID>",
@@ -883,6 +943,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->deleteExecution(
             "<FUNCTION_ID>",
@@ -913,6 +976,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->listVariables(
             "<FUNCTION_ID>"
@@ -937,6 +1003,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->createVariable(
             "<FUNCTION_ID>",
@@ -964,6 +1033,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->getVariable(
             "<FUNCTION_ID>",
@@ -989,6 +1061,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->updateVariable(
             "<FUNCTION_ID>",
@@ -1005,6 +1080,9 @@ final class FunctionsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->functions->deleteVariable(
             "<FUNCTION_ID>",

--- a/tests/Appwrite/Services/GraphqlTest.php
+++ b/tests/Appwrite/Services/GraphqlTest.php
@@ -25,6 +25,9 @@ final class GraphqlTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->graphql->query(
             array()
@@ -40,6 +43,9 @@ final class GraphqlTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->graphql->mutation(
             array()

--- a/tests/Appwrite/Services/HealthTest.php
+++ b/tests/Appwrite/Services/HealthTest.php
@@ -30,6 +30,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->get();
 
@@ -46,10 +49,38 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getAntivirus();
 
         $this->assertInstanceOf(\Appwrite\Models\HealthAntivirus::class, $response);
+    }
+
+    public function testMethodGetAuditsDB(): void
+    {
+        $data = array(
+            "total" => 5,
+            "statuses" => array(
+                array(
+                    "name" => "database",
+                    "ping" => 128,
+                    "status" => "pass"
+                )
+            )
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
+
+        $response = $this->health->getAuditsDB();
+
+        $this->assertInstanceOf(\Appwrite\Models\HealthStatusList::class, $response);
     }
 
     public function testMethodGetCache(): void
@@ -68,6 +99,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getCache();
 
@@ -88,6 +122,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getCertificate();
 
@@ -105,6 +142,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getConsolePausing();
 
@@ -127,6 +167,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getDB();
 
@@ -149,6 +192,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getPubSub();
 
@@ -164,6 +210,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueAudits();
 
@@ -179,6 +228,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueBuilds();
 
@@ -194,6 +246,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueCertificates();
 
@@ -209,6 +264,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueDatabases();
 
@@ -224,6 +282,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueDeletes();
 
@@ -239,6 +300,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getFailedJobs(
             HealthQueueName::V1DATABASE()
@@ -256,6 +320,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueFunctions();
 
@@ -271,6 +338,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueLogs();
 
@@ -286,6 +356,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueMails();
 
@@ -301,6 +374,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueMessaging();
 
@@ -316,6 +392,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueMigrations();
 
@@ -331,6 +410,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueStatsResources();
 
@@ -346,6 +428,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueUsage();
 
@@ -361,6 +446,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getQueueWebhooks();
 
@@ -378,6 +466,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getStorage();
 
@@ -395,6 +486,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getStorageLocal();
 
@@ -412,6 +506,9 @@ final class HealthTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->health->getTime();
 

--- a/tests/Appwrite/Services/LocaleTest.php
+++ b/tests/Appwrite/Services/LocaleTest.php
@@ -33,6 +33,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->get();
 
@@ -54,6 +57,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listCodes();
 
@@ -75,6 +81,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listContinents();
 
@@ -96,6 +105,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listCountries();
 
@@ -117,6 +129,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listCountriesEU();
 
@@ -139,6 +154,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listCountriesPhones();
 
@@ -165,6 +183,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listCurrencies();
 
@@ -187,6 +208,9 @@ final class LocaleTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->locale->listLanguages();
 

--- a/tests/Appwrite/Services/MessagingTest.php
+++ b/tests/Appwrite/Services/MessagingTest.php
@@ -43,6 +43,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listMessages();
 
@@ -67,6 +70,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createEmail(
             "<MESSAGE_ID>",
@@ -95,6 +101,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateEmail(
             "<MESSAGE_ID>"
@@ -121,6 +130,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createPush(
             "<MESSAGE_ID>"
@@ -147,6 +159,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updatePush(
             "<MESSAGE_ID>"
@@ -173,6 +188,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createSMS(
             "<MESSAGE_ID>",
@@ -200,6 +218,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateSMS(
             "<MESSAGE_ID>"
@@ -226,6 +247,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->getMessage(
             "<MESSAGE_ID>"
@@ -241,6 +265,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->delete(
             "<MESSAGE_ID>"
@@ -284,6 +311,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listMessageLogs(
             "<MESSAGE_ID>"
@@ -313,6 +343,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listTargets(
             "<MESSAGE_ID>"
@@ -342,6 +375,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listProviders();
 
@@ -364,6 +400,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createAPNSProvider(
             "<PROVIDER_ID>",
@@ -389,6 +428,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateAPNSProvider(
             "<PROVIDER_ID>"
@@ -413,6 +455,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createFCMProvider(
             "<PROVIDER_ID>",
@@ -438,6 +483,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateFCMProvider(
             "<PROVIDER_ID>"
@@ -462,6 +510,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createMailgunProvider(
             "<PROVIDER_ID>",
@@ -487,6 +538,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateMailgunProvider(
             "<PROVIDER_ID>"
@@ -511,6 +565,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createMsg91Provider(
             "<PROVIDER_ID>",
@@ -536,6 +593,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateMsg91Provider(
             "<PROVIDER_ID>"
@@ -560,6 +620,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createResendProvider(
             "<PROVIDER_ID>",
@@ -585,6 +648,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateResendProvider(
             "<PROVIDER_ID>"
@@ -609,6 +675,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createSendgridProvider(
             "<PROVIDER_ID>",
@@ -634,8 +703,66 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateSendgridProvider(
+            "<PROVIDER_ID>"
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Provider::class, $response);
+    }
+
+    public function testMethodCreateSesProvider(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "Mailgun",
+            "provider" => "mailgun",
+            "enabled" => true,
+            "type" => "sms",
+            "credentials" => array()
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
+
+        $response = $this->messaging->createSesProvider(
+            "<PROVIDER_ID>",
+            "<NAME>"
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Provider::class, $response);
+    }
+
+    public function testMethodUpdateSesProvider(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "Mailgun",
+            "provider" => "mailgun",
+            "enabled" => true,
+            "type" => "sms",
+            "credentials" => array()
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
+
+        $response = $this->messaging->updateSesProvider(
             "<PROVIDER_ID>"
         );
 
@@ -658,6 +785,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createSMTPProvider(
             "<PROVIDER_ID>",
@@ -684,6 +814,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateSMTPProvider(
             "<PROVIDER_ID>"
@@ -708,6 +841,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createTelesignProvider(
             "<PROVIDER_ID>",
@@ -733,6 +869,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateTelesignProvider(
             "<PROVIDER_ID>"
@@ -757,6 +896,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createTextmagicProvider(
             "<PROVIDER_ID>",
@@ -782,6 +924,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateTextmagicProvider(
             "<PROVIDER_ID>"
@@ -806,6 +951,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createTwilioProvider(
             "<PROVIDER_ID>",
@@ -831,6 +979,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateTwilioProvider(
             "<PROVIDER_ID>"
@@ -855,6 +1006,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createVonageProvider(
             "<PROVIDER_ID>",
@@ -880,6 +1034,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateVonageProvider(
             "<PROVIDER_ID>"
@@ -904,6 +1061,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->getProvider(
             "<PROVIDER_ID>"
@@ -919,6 +1079,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->deleteProvider(
             "<PROVIDER_ID>"
@@ -962,6 +1125,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listProviderLogs(
             "<PROVIDER_ID>"
@@ -1005,6 +1171,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listSubscriberLogs(
             "<SUBSCRIBER_ID>"
@@ -1034,6 +1203,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listTopics();
 
@@ -1056,6 +1228,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createTopic(
             "<TOPIC_ID>",
@@ -1081,6 +1256,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->getTopic(
             "<TOPIC_ID>"
@@ -1105,6 +1283,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->updateTopic(
             "<TOPIC_ID>"
@@ -1120,6 +1301,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->deleteTopic(
             "<TOPIC_ID>"
@@ -1163,6 +1347,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listTopicLogs(
             "<TOPIC_ID>"
@@ -1202,6 +1389,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->listSubscribers(
             "<TOPIC_ID>"
@@ -1236,6 +1426,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->createSubscriber(
             "<TOPIC_ID>",
@@ -1272,6 +1465,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->getSubscriber(
             "<TOPIC_ID>",
@@ -1288,6 +1484,9 @@ final class MessagingTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->messaging->deleteSubscriber(
             "<TOPIC_ID>",

--- a/tests/Appwrite/Services/OrganizationTest.php
+++ b/tests/Appwrite/Services/OrganizationTest.php
@@ -42,6 +42,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->listKeys();
 
@@ -65,6 +68,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->createKey(
             "<KEY_ID>",
@@ -92,6 +98,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->getKey(
             "<KEY_ID>"
@@ -117,6 +126,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->updateKey(
             "<KEY_ID>",
@@ -134,6 +146,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->deleteKey(
             "<KEY_ID>"
@@ -153,6 +168,7 @@ final class OrganizationTest extends TestCase
                     "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
                     "name" => "New Project",
                     "teamId" => "1592981250",
+                    "region" => "fra",
                     "devKeys" => array(
                         array(
                             "\$id" => "5e5ea5c16897e",
@@ -197,7 +213,6 @@ final class OrganizationTest extends TestCase
                             "enabled" => true
                         )
                     ),
-                    "region" => "fra",
                     "blocks" => array(
                         array(
                             "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -210,7 +225,16 @@ final class OrganizationTest extends TestCase
                             "billingPlan" => "pro"
                         )
                     ),
-                    "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+                    "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "oAuth2ServerEnabled" => true,
+                    "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+                    "oAuth2ServerScopes" => array(),
+                    "oAuth2ServerAccessTokenDuration" => 3600,
+                    "oAuth2ServerRefreshTokenDuration" => 86400,
+                    "oAuth2ServerPublicAccessTokenDuration" => 3600,
+                    "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+                    "oAuth2ServerConfidentialPkce" => true,
+                    "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
                 )
             )
         );
@@ -218,6 +242,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->listProjects();
 
@@ -232,6 +259,7 @@ final class OrganizationTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -276,7 +304,6 @@ final class OrganizationTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -289,12 +316,24 @@ final class OrganizationTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->createProject(
             "",
@@ -312,6 +351,7 @@ final class OrganizationTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -356,7 +396,6 @@ final class OrganizationTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -369,12 +408,24 @@ final class OrganizationTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->getProject(
             "<PROJECT_ID>"
@@ -391,6 +442,7 @@ final class OrganizationTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -435,7 +487,6 @@ final class OrganizationTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -448,12 +499,24 @@ final class OrganizationTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->updateProject(
             "<PROJECT_ID>",
@@ -470,6 +533,9 @@ final class OrganizationTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->organization->deleteProject(
             "<PROJECT_ID>"

--- a/tests/Appwrite/Services/PresencesTest.php
+++ b/tests/Appwrite/Services/PresencesTest.php
@@ -37,6 +37,9 @@ final class PresencesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->presences->list();
 
@@ -57,6 +60,9 @@ final class PresencesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->presences->get(
             "<PRESENCE_ID>"
@@ -79,6 +85,9 @@ final class PresencesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->presences->upsert(
             "<PRESENCE_ID>",
@@ -103,6 +112,9 @@ final class PresencesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->presences->update(
             "<PRESENCE_ID>",
@@ -119,6 +131,9 @@ final class PresencesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->presences->delete(
             "<PRESENCE_ID>"

--- a/tests/Appwrite/Services/ProjectTest.php
+++ b/tests/Appwrite/Services/ProjectTest.php
@@ -36,6 +36,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -80,7 +81,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -93,12 +93,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->get();
 
@@ -112,6 +124,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->delete();
 
@@ -126,6 +141,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -170,7 +186,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -183,12 +198,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateAuthMethod(
             ProjectAuthMethodId::EMAILPASSWORD(),
@@ -220,6 +247,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listKeys();
 
@@ -243,6 +273,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createKey(
             "<KEY_ID>",
@@ -270,6 +303,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createEphemeralKey(
             array(ProjectKeyScopes::PROJECTREAD()),
@@ -296,6 +332,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getKey(
             "<KEY_ID>"
@@ -321,6 +360,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateKey(
             "<KEY_ID>",
@@ -338,6 +380,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->deleteKey(
             "<KEY_ID>"
@@ -354,6 +399,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -398,7 +444,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -411,12 +456,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateLabels(
             array()
@@ -442,6 +499,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listMockPhones();
 
@@ -460,6 +520,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createMockPhone(
             "+12065550100",
@@ -481,6 +544,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getMockPhone(
             "+12065550100"
@@ -501,6 +567,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateMockPhone(
             "+12065550100",
@@ -517,6 +586,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->deleteMockPhone(
             "+12065550100"
@@ -535,10 +607,105 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listOAuth2Providers();
 
         $this->assertInstanceOf(\Appwrite\Models\OAuth2ProviderList::class, $response);
+    }
+
+    public function testMethodUpdateOAuth2Server(): void
+    {
+        $data = array(
+            "\$id" => "5e5ea5c16897e",
+            "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+            "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+            "name" => "New Project",
+            "teamId" => "1592981250",
+            "region" => "fra",
+            "devKeys" => array(
+                array(
+                    "\$id" => "5e5ea5c16897e",
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "name" => "Dev API Key",
+                    "expire" => "2020-10-15T06:38:00.000+00:00",
+                    "secret" => "919c2d18fb5d4...a2ae413da83346ad2",
+                    "accessedAt" => "2020-10-15T06:38:00.000+00:00",
+                    "sdks" => array()
+                )
+            ),
+            "smtpEnabled" => true,
+            "smtpSenderName" => "John Appwrite",
+            "smtpSenderEmail" => "john@appwrite.io",
+            "smtpReplyToName" => "Support Team",
+            "smtpReplyToEmail" => "support@appwrite.io",
+            "smtpHost" => "mail.appwrite.io",
+            "smtpPort" => 25,
+            "smtpUsername" => "emailuser",
+            "smtpPassword" => "[SMTPPASSWORD]",
+            "smtpSecure" => "tls",
+            "pingCount" => 1,
+            "pingedAt" => "2020-10-15T06:38:00.000+00:00",
+            "labels" => array(),
+            "status" => "active",
+            "authMethods" => array(
+                array(
+                    "\$id" => "email-password",
+                    "enabled" => true
+                )
+            ),
+            "services" => array(
+                array(
+                    "\$id" => "account",
+                    "enabled" => true
+                )
+            ),
+            "protocols" => array(
+                array(
+                    "\$id" => "rest",
+                    "enabled" => true
+                )
+            ),
+            "blocks" => array(
+                array(
+                    "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
+                    "resourceType" => "project",
+                    "resourceId" => "5e5ea5c16897e",
+                    "projectName" => "My Project",
+                    "region" => "fra",
+                    "organizationName" => "Acme Inc.",
+                    "organizationId" => "5e5ea5c16897e",
+                    "billingPlan" => "pro"
+                )
+            ),
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
+
+        $response = $this->project->updateOAuth2Server(
+            true,
+            "https://example.com"
+        );
+
+        $this->assertInstanceOf(\Appwrite\Models\Project::class, $response);
     }
 
     public function testMethodUpdateOAuth2Amazon(): void
@@ -547,12 +714,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "amzn1.application-oa2-client.87400c00000000000000000000063d5b2",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "79ffe4000000000000000000000000000000000000000000000000000002de55"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Amazon();
 
@@ -573,6 +743,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Apple();
 
@@ -585,13 +758,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "OaOkIA000000000000000000005KLSYq",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "zXz0000-00000000000000000000000000000-00000000000000000000PJafnF",
             "endpoint" => "example.us.auth0.com"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Auth0();
 
@@ -604,13 +780,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "dTKOPa0000000000000000000000000000e7G8hv",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "ntQadq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000Hp5WK",
             "endpoint" => "example.authentik.com"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Authentik();
 
@@ -623,12 +802,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "5zw90v00000000000000000000kVYXN7",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "7I000000000000MW"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Autodesk();
 
@@ -641,12 +823,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "key" => "Knt70000000000ByRc",
-            "secret" => "your-oauth2-client-secret"
+            "secret" => "NMfLZJ00000000000000000000TLQdDx"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Bitbucket();
 
@@ -659,12 +844,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "d95151000000000000000000000000000067af9b",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "a13e250000000000000000000000000000d73095"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Bitly();
 
@@ -677,12 +865,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "deglcs00000000000000000000x2og6y",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "OKM1f100000000000000000000eshEif"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Box();
 
@@ -695,12 +886,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "apiKey" => "07a9000000000000067f",
-            "apiSecret" => "your-oauth2-client-secret"
+            "apiSecret" => "a399a90000000000000000000000000000d90639"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Dailymotion();
 
@@ -713,12 +907,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "950722000000343754",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "YmPXnM000000000000000000002zFg5D"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Discord();
 
@@ -731,12 +928,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "publicKey" => "cgegH70000000000000000000000000000000000000000000000000000Hr1nYX",
-            "secretKey" => "your-oauth2-client-secret"
+            "secretKey" => "W7Bykj00000000000000000000000000000000000000000000000000003o43w9"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Disqus();
 
@@ -749,12 +949,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "appKey" => "jl000000000009t",
-            "appSecret" => "your-oauth2-client-secret"
+            "appSecret" => "g200000000000vw"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Dropbox();
 
@@ -767,12 +970,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "keyString" => "nsgzxh0000000000008j85a2",
-            "sharedSecret" => "your-oauth2-client-secret"
+            "sharedSecret" => "tp000000ru"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Etsy();
 
@@ -785,12 +991,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "appId" => "260600000007694",
-            "appSecret" => "your-oauth2-client-secret"
+            "appSecret" => "2d0b2800000000000000000000d38af4"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Facebook();
 
@@ -803,12 +1012,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "byay5H0000000000VtiI40",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "yEpOYn0000000000000000004iIsU5"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Figma();
 
@@ -821,13 +1033,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "b2222c00-0000-0000-0000-000000862097",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "Jx4s0C0000000000000000000000000000000wGqLsc",
             "endpoint" => "example.fusionauth.io"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2FusionAuth();
 
@@ -840,12 +1055,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "e4d87900000000540733",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "5e07c00000000000000000000000000000198bcc"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2GitHub();
 
@@ -858,13 +1076,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "applicationId" => "d41ffe0000000000000000000000000000000000000000000000000000d5e252",
-            "secret" => "your-oauth2-client-secret",
+            "secret" => "gloas-838cfa0000000000000000000000000000000000000000000000000000ecbb38",
             "endpoint" => "https://gitlab.com"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Gitlab();
 
@@ -877,13 +1098,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "120000000095-92ifjb00000000000000000000g7ijfb.apps.googleusercontent.com",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "GOCSPX-2k8gsR0000000000000000VNahJj",
             "prompt" => array()
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Google();
 
@@ -896,7 +1120,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "appwrite-o0000000st-app",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "jdjrJd00000000000000000000HUsaZO",
             "endpoint" => "keycloak.example.com",
             "realmName" => "appwrite-realm"
         );
@@ -904,6 +1128,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Keycloak();
 
@@ -916,12 +1143,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "01KQ7C00000000000001MFHS32",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "34ac5600000000000000000000000000000000000000000000000000e830c8b"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Kick();
 
@@ -934,12 +1164,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "770000000000dv",
-            "primaryClientSecret" => "your-oauth2-client-secret"
+            "primaryClientSecret" => "WPL_AP1.2Bf0000000000000./HtlYw=="
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Linkedin();
 
@@ -952,13 +1185,16 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "applicationId" => "00001111-aaaa-2222-bbbb-3333cccc4444",
-            "applicationSecret" => "your-oauth2-client-secret",
+            "applicationSecret" => "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u",
             "tenant" => "common"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Microsoft();
 
@@ -971,12 +1207,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauthClientId" => "341d8700-0000-0000-0000-000000446ee3",
-            "oauthClientSecret" => "your-oauth2-client-secret"
+            "oauthClientSecret" => "secret_dLUr4b000000000000000000000000000000lFHAa9"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Notion();
 
@@ -989,7 +1228,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "qibI2x0000000000000000000000000006L2YFoG",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "Ah68ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003qpcHV",
             "wellKnownURL" => "https://myoauth.com/.well-known/openid-configuration",
             "authorizationURL" => "https://myoauth.com/oauth2/authorize",
             "tokenURL" => "https://myoauth.com/oauth2/token",
@@ -999,6 +1238,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Oidc();
 
@@ -1011,7 +1253,7 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "0oa00000000000000698",
-            "clientSecret" => "your-oauth2-client-secret",
+            "clientSecret" => "Kiq0000000000000000000000000000000000000-00000000000H2L5-3SJ-vRV",
             "domain" => "trial-6400025.okta.com",
             "authorizationServerId" => "aus000000000000000h7z"
         );
@@ -1019,6 +1261,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Okta();
 
@@ -1031,12 +1276,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB",
-            "secretKey" => "your-oauth2-client-secret"
+            "secretKey" => "EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Paypal();
 
@@ -1049,12 +1297,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "AdhIEG7-000000000000-0000000000000000000000000000000-0000000000000000000000-2pyB",
-            "secretKey" => "your-oauth2-client-secret"
+            "secretKey" => "EH8KCXtew--000000000000000000000000000000000000000_C-1_5UP_000000000000000CB7KDp"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2PaypalSandbox();
 
@@ -1067,12 +1318,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "appwrite-oauth-test-app",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "Rn247T0000000000000000000000000000000000000000000000000000W2zWTN"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Podio();
 
@@ -1085,12 +1339,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "customerKey" => "3MVG9I0000000000000000000000000000000000000000000000000000000000000000000000000C5Aejq",
-            "customerSecret" => "your-oauth2-client-secret"
+            "customerSecret" => "3w000000000000e2"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Salesforce();
 
@@ -1103,12 +1360,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "23000000089.15000000000023",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "81656000000000000000000000f3d2fd"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Slack();
 
@@ -1121,12 +1381,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "6ec271000000000000000000009beace",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "db068a000000000000000000008b5b9f"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Spotify();
 
@@ -1139,12 +1402,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "ca_UKibXX0000000000000000000006byvR",
-            "apiSecretKey" => "your-oauth2-client-secret"
+            "apiSecretKey" => "sk_51SfOd000000000000000000000000000000000000000000000000000000000000000000000000000000000000000QGWYfp"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Stripe();
 
@@ -1157,12 +1423,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauth2ClientId" => "appwrite-test-org.appwrite-test-app",
-            "oauth2ClientSecret" => "your-oauth2-client-secret"
+            "oauth2ClientSecret" => "7cb52700-0000-0000-0000-000000ca5b83"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Tradeshift();
 
@@ -1175,12 +1444,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "oauth2ClientId" => "appwrite-test-org.appwrite-test-app",
-            "oauth2ClientSecret" => "your-oauth2-client-secret"
+            "oauth2ClientSecret" => "7cb52700-0000-0000-0000-000000ca5b83"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2TradeshiftSandbox();
 
@@ -1193,12 +1465,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "vvi0in000000000000000000ikmt9p",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "pmapue000000000000000000zylw3v"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Twitch();
 
@@ -1211,12 +1486,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "130005",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "PlBfJS0000000000000000000000000000000000000000000000000000EdUZJk"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2WordPress();
 
@@ -1229,12 +1507,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "customerKey" => "slzZV0000000000000NFLaWT",
-            "secretKey" => "your-oauth2-client-secret"
+            "secretKey" => "tkEPkp00000000000000000000000000000000000000FTxbI9"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2X();
 
@@ -1247,12 +1528,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "dj0yJm000000000000000000000000000000000000000000000000000000000000000000000000000000000000Z4PWRm",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "cf978f0000000000000000000000000000c5e2e9"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Yahoo();
 
@@ -1265,12 +1549,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "6a8a6a0000000000000000000091483c",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "bbf98500000000000000000000c75a63"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Yandex();
 
@@ -1283,12 +1570,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "1000.83C178000000000000000000RPNX0B",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "fb5cac000000000000000000000000000000a68f6e"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Zoho();
 
@@ -1301,12 +1591,15 @@ final class ProjectTest extends TestCase
             "\$id" => "github",
             "enabled" => true,
             "clientId" => "QMAC00000000000000w0AQ",
-            "clientSecret" => "your-oauth2-client-secret"
+            "clientSecret" => "GAWsG4000000000000000000007U01ON"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateOAuth2Zoom();
 
@@ -1320,7 +1613,7 @@ final class ProjectTest extends TestCase
                 "\$id" => "github",
                 "enabled" => true,
                 "applicationId" => "00001111-aaaa-2222-bbbb-3333cccc4444",
-                "applicationSecret" => "your-oauth2-client-secret",
+                "applicationSecret" => "A1bC2dE3fH4iJ5kL6mN7oP8qR9sT0u",
                 "tenant" => "common"
             ),
             array(
@@ -1331,6 +1624,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getOAuth2Provider(
             ProjectOAuthProviderId::AMAZON()
@@ -1349,6 +1645,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listPlatforms();
 
@@ -1369,6 +1668,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createAndroidPlatform(
             "<PLATFORM_ID>",
@@ -1393,6 +1695,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateAndroidPlatform(
             "<PLATFORM_ID>",
@@ -1417,6 +1722,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createApplePlatform(
             "<PLATFORM_ID>",
@@ -1441,6 +1749,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateApplePlatform(
             "<PLATFORM_ID>",
@@ -1465,6 +1776,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createLinuxPlatform(
             "<PLATFORM_ID>",
@@ -1489,6 +1803,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateLinuxPlatform(
             "<PLATFORM_ID>",
@@ -1513,6 +1830,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createWebPlatform(
             "<PLATFORM_ID>",
@@ -1537,6 +1857,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateWebPlatform(
             "<PLATFORM_ID>",
@@ -1561,6 +1884,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createWindowsPlatform(
             "<PLATFORM_ID>",
@@ -1585,6 +1911,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateWindowsPlatform(
             "<PLATFORM_ID>",
@@ -1614,6 +1943,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getPlatform(
             "<PLATFORM_ID>"
@@ -1629,6 +1961,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->deletePlatform(
             "<PLATFORM_ID>"
@@ -1640,13 +1975,16 @@ final class ProjectTest extends TestCase
     public function testMethodListPolicies(): void
     {
         $data = array(
-            "total" => 9,
+            "total" => 10,
             "policies" => array()
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listPolicies();
 
@@ -1661,6 +1999,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -1705,7 +2044,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -1718,12 +2056,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateDenyAliasedEmailPolicy(
             true
@@ -1740,6 +2090,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -1784,7 +2135,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -1797,12 +2147,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateDenyDisposableEmailPolicy(
             true
@@ -1819,6 +2181,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -1863,7 +2226,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -1876,12 +2238,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateDenyFreeEmailPolicy(
             true
@@ -1898,6 +2272,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -1942,7 +2317,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -1955,12 +2329,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateMembershipPrivacyPolicy();
 
@@ -1975,6 +2361,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2019,7 +2406,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2032,12 +2418,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updatePasswordDictionaryPolicy(
             true
@@ -2054,6 +2452,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2098,7 +2497,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2111,12 +2509,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updatePasswordHistoryPolicy(
             1
@@ -2133,6 +2543,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2177,7 +2588,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2190,18 +2600,53 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updatePasswordPersonalDataPolicy(
             true
         );
 
         $this->assertInstanceOf(\Appwrite\Models\Project::class, $response);
+    }
+
+    public function testMethodUpdatePasswordStrengthPolicy(): void
+    {
+        $data = array(
+            "\$id" => "password-dictionary",
+            "min" => 12,
+            "uppercase" => true,
+            "lowercase" => true,
+            "number" => true,
+            "symbols" => true
+        );
+
+        $this->client
+            ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
+            ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
+
+        $response = $this->project->updatePasswordStrengthPolicy();
+
+        $this->assertInstanceOf(\Appwrite\Models\PolicyPasswordStrength::class, $response);
     }
 
     public function testMethodUpdateSessionAlertPolicy(): void
@@ -2212,6 +2657,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2256,7 +2702,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2269,12 +2714,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateSessionAlertPolicy(
             true
@@ -2291,6 +2748,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2335,7 +2793,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2348,12 +2805,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateSessionDurationPolicy(
             1
@@ -2370,6 +2839,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2414,7 +2884,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2427,12 +2896,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateSessionInvalidationPolicy(
             true
@@ -2449,6 +2930,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2493,7 +2975,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2506,12 +2987,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateSessionLimitPolicy(
             1
@@ -2528,6 +3021,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2572,7 +3066,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2585,12 +3078,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateUserLimitPolicy(
             1
@@ -2614,6 +3119,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getPolicy(
             ProjectPolicyId::PASSWORDDICTIONARY()
@@ -2630,6 +3138,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2674,7 +3183,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2687,12 +3195,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateProtocol(
             ProjectProtocolId::REST(),
@@ -2710,6 +3230,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2754,7 +3275,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2767,12 +3287,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateService(
             ProjectServiceId::ACCOUNT(),
@@ -2790,6 +3322,7 @@ final class ProjectTest extends TestCase
             "\$updatedAt" => "2020-10-15T06:38:00.000+00:00",
             "name" => "New Project",
             "teamId" => "1592981250",
+            "region" => "fra",
             "devKeys" => array(
                 array(
                     "\$id" => "5e5ea5c16897e",
@@ -2834,7 +3367,6 @@ final class ProjectTest extends TestCase
                     "enabled" => true
                 )
             ),
-            "region" => "fra",
             "blocks" => array(
                 array(
                     "\$createdAt" => "2020-10-15T06:38:00.000+00:00",
@@ -2847,12 +3379,24 @@ final class ProjectTest extends TestCase
                     "billingPlan" => "pro"
                 )
             ),
-            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00"
+            "consoleAccessedAt" => "2020-10-15T06:38:00.000+00:00",
+            "oAuth2ServerEnabled" => true,
+            "oAuth2ServerAuthorizationUrl" => "https://cloud.appwrite.io/oauth2/.well-known/openid-configuration",
+            "oAuth2ServerScopes" => array(),
+            "oAuth2ServerAccessTokenDuration" => 3600,
+            "oAuth2ServerRefreshTokenDuration" => 86400,
+            "oAuth2ServerPublicAccessTokenDuration" => 3600,
+            "oAuth2ServerPublicRefreshTokenDuration" => 2592000,
+            "oAuth2ServerConfidentialPkce" => true,
+            "oAuth2ServerDiscoveryUrl" => "https://auth.example.com/.well-known/openid-configuration"
         );
 
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateSMTP();
 
@@ -2866,6 +3410,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createSMTPTest(
             array()
@@ -2895,6 +3442,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listEmailTemplates();
 
@@ -2917,6 +3467,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateEmailTemplate(
             ProjectEmailTemplateId::VERIFICATION()
@@ -2941,6 +3494,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getEmailTemplate(
             ProjectEmailTemplateId::VERIFICATION()
@@ -2970,6 +3526,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->listVariables();
 
@@ -2992,6 +3551,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->createVariable(
             "<VARIABLE_ID>",
@@ -3018,6 +3580,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->getVariable(
             "<VARIABLE_ID>"
@@ -3042,6 +3607,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->updateVariable(
             "<VARIABLE_ID>"
@@ -3057,6 +3625,9 @@ final class ProjectTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->project->deleteVariable(
             "<VARIABLE_ID>"

--- a/tests/Appwrite/Services/ProxyTest.php
+++ b/tests/Appwrite/Services/ProxyTest.php
@@ -47,6 +47,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->listRules();
 
@@ -75,6 +78,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->createAPIRule(
             ""
@@ -105,6 +111,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->createFunctionRule(
             "",
@@ -136,6 +145,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->createRedirectRule(
             "",
@@ -170,6 +182,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->createSiteRule(
             "",
@@ -201,6 +216,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->getRule(
             "<RULE_ID>"
@@ -216,6 +234,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->deleteRule(
             "<RULE_ID>"
@@ -246,6 +267,9 @@ final class ProxyTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->proxy->updateRuleStatus(
             "<RULE_ID>"

--- a/tests/Appwrite/Services/SitesTest.php
+++ b/tests/Appwrite/Services/SitesTest.php
@@ -82,6 +82,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->list();
 
@@ -141,6 +144,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->create(
             "<SITE_ID>",
@@ -178,6 +184,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->listFrameworks();
 
@@ -201,6 +210,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->listSpecifications();
 
@@ -260,6 +272,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->get(
             "<SITE_ID>"
@@ -321,6 +336,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->update(
             "<SITE_ID>",
@@ -338,6 +356,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->delete(
             "<SITE_ID>"
@@ -399,6 +420,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->updateSiteDeployment(
             "<SITE_ID>",
@@ -448,6 +472,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->listDeployments(
             "<SITE_ID>"
@@ -491,6 +518,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->createDeployment(
             "<SITE_ID>",
@@ -535,6 +565,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->createDuplicateDeployment(
             "<SITE_ID>",
@@ -579,6 +612,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->createTemplateDeployment(
             "<SITE_ID>",
@@ -627,6 +663,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->createVcsDeployment(
             "<SITE_ID>",
@@ -672,6 +711,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->getDeployment(
             "<SITE_ID>",
@@ -688,6 +730,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->deleteDeployment(
             "<SITE_ID>",
@@ -704,6 +749,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->getDeploymentDownload(
             "<SITE_ID>",
@@ -748,6 +796,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->updateDeploymentStatus(
             "<SITE_ID>",
@@ -797,6 +848,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->listLogs(
             "<SITE_ID>"
@@ -840,6 +894,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->getLog(
             "<SITE_ID>",
@@ -856,6 +913,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->deleteLog(
             "<SITE_ID>",
@@ -886,6 +946,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->listVariables(
             "<SITE_ID>"
@@ -910,6 +973,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->createVariable(
             "<SITE_ID>",
@@ -937,6 +1003,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->getVariable(
             "<SITE_ID>",
@@ -962,6 +1031,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->updateVariable(
             "<SITE_ID>",
@@ -978,6 +1050,9 @@ final class SitesTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->sites->deleteVariable(
             "<SITE_ID>",

--- a/tests/Appwrite/Services/StorageTest.php
+++ b/tests/Appwrite/Services/StorageTest.php
@@ -48,6 +48,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->listBuckets();
 
@@ -76,6 +79,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->createBucket(
             "<BUCKET_ID>",
@@ -107,6 +113,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->getBucket(
             "<BUCKET_ID>"
@@ -137,6 +146,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->updateBucket(
             "<BUCKET_ID>",
@@ -153,6 +165,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->deleteBucket(
             "<BUCKET_ID>"
@@ -188,6 +203,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->listFiles(
             "<BUCKET_ID>"
@@ -218,6 +236,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->createFile(
             "<BUCKET_ID>",
@@ -250,6 +271,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->getFile(
             "<BUCKET_ID>",
@@ -281,6 +305,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->updateFile(
             "<BUCKET_ID>",
@@ -297,6 +324,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->deleteFile(
             "<BUCKET_ID>",
@@ -313,6 +343,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->getFileDownload(
             "<BUCKET_ID>",
@@ -329,6 +362,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->getFilePreview(
             "<BUCKET_ID>",
@@ -345,6 +381,9 @@ final class StorageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->storage->getFileView(
             "<BUCKET_ID>",

--- a/tests/Appwrite/Services/TablesDBTest.php
+++ b/tests/Appwrite/Services/TablesDBTest.php
@@ -68,6 +68,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->list();
 
@@ -115,6 +118,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->create(
             "<DATABASE_ID>",
@@ -143,6 +149,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->listTransactions();
 
@@ -163,6 +172,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createTransaction();
 
@@ -183,6 +195,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->getTransaction(
             "<TRANSACTION_ID>"
@@ -205,6 +220,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateTransaction(
             "<TRANSACTION_ID>"
@@ -220,6 +238,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteTransaction(
             "<TRANSACTION_ID>"
@@ -242,6 +263,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createOperations(
             "<TRANSACTION_ID>"
@@ -291,6 +315,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->get(
             "<DATABASE_ID>"
@@ -340,6 +367,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->update(
             "<DATABASE_ID>"
@@ -355,6 +385,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->delete(
             "<DATABASE_ID>"
@@ -400,6 +433,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->listTables(
             "<DATABASE_ID>"
@@ -440,6 +476,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createTable(
             "<DATABASE_ID>",
@@ -482,6 +521,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->getTable(
             "<DATABASE_ID>",
@@ -523,6 +565,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateTable(
             "<DATABASE_ID>",
@@ -539,6 +584,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteTable(
             "<DATABASE_ID>",
@@ -558,6 +606,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->listColumns(
             "<DATABASE_ID>",
@@ -582,6 +633,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createBigIntColumn(
             "<DATABASE_ID>",
@@ -608,6 +662,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateBigIntColumn(
             "<DATABASE_ID>",
@@ -635,6 +692,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createBooleanColumn(
             "<DATABASE_ID>",
@@ -661,6 +721,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateBooleanColumn(
             "<DATABASE_ID>",
@@ -689,6 +752,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createDatetimeColumn(
             "<DATABASE_ID>",
@@ -716,6 +782,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateDatetimeColumn(
             "<DATABASE_ID>",
@@ -744,6 +813,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createEmailColumn(
             "<DATABASE_ID>",
@@ -771,6 +843,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateEmailColumn(
             "<DATABASE_ID>",
@@ -800,6 +875,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createEnumColumn(
             "<DATABASE_ID>",
@@ -829,6 +907,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateEnumColumn(
             "<DATABASE_ID>",
@@ -857,6 +938,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createFloatColumn(
             "<DATABASE_ID>",
@@ -883,6 +967,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateFloatColumn(
             "<DATABASE_ID>",
@@ -910,6 +997,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createIntegerColumn(
             "<DATABASE_ID>",
@@ -936,6 +1026,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateIntegerColumn(
             "<DATABASE_ID>",
@@ -964,6 +1057,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createIpColumn(
             "<DATABASE_ID>",
@@ -991,6 +1087,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateIpColumn(
             "<DATABASE_ID>",
@@ -1018,6 +1117,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createLineColumn(
             "<DATABASE_ID>",
@@ -1044,6 +1146,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateLineColumn(
             "<DATABASE_ID>",
@@ -1070,6 +1175,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createLongtextColumn(
             "<DATABASE_ID>",
@@ -1096,6 +1204,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateLongtextColumn(
             "<DATABASE_ID>",
@@ -1123,6 +1234,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createMediumtextColumn(
             "<DATABASE_ID>",
@@ -1149,6 +1263,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateMediumtextColumn(
             "<DATABASE_ID>",
@@ -1176,6 +1293,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createPointColumn(
             "<DATABASE_ID>",
@@ -1202,6 +1322,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updatePointColumn(
             "<DATABASE_ID>",
@@ -1228,6 +1351,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createPolygonColumn(
             "<DATABASE_ID>",
@@ -1254,6 +1380,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updatePolygonColumn(
             "<DATABASE_ID>",
@@ -1286,6 +1415,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createRelationshipColumn(
             "<DATABASE_ID>",
@@ -1313,6 +1445,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createStringColumn(
             "<DATABASE_ID>",
@@ -1341,6 +1476,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateStringColumn(
             "<DATABASE_ID>",
@@ -1368,6 +1506,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createTextColumn(
             "<DATABASE_ID>",
@@ -1394,6 +1535,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateTextColumn(
             "<DATABASE_ID>",
@@ -1422,6 +1566,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createUrlColumn(
             "<DATABASE_ID>",
@@ -1449,6 +1596,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateUrlColumn(
             "<DATABASE_ID>",
@@ -1477,6 +1627,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createVarcharColumn(
             "<DATABASE_ID>",
@@ -1505,6 +1658,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateVarcharColumn(
             "<DATABASE_ID>",
@@ -1538,6 +1694,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->getColumn(
             "<DATABASE_ID>",
@@ -1555,6 +1714,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteColumn(
             "<DATABASE_ID>",
@@ -1586,6 +1748,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateRelationshipColumn(
             "<DATABASE_ID>",
@@ -1618,6 +1783,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->listIndexes(
             "<DATABASE_ID>",
@@ -1644,6 +1812,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createIndex(
             "<DATABASE_ID>",
@@ -1673,6 +1844,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->getIndex(
             "<DATABASE_ID>",
@@ -1690,6 +1864,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteIndex(
             "<DATABASE_ID>",
@@ -1720,6 +1897,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->listRows(
             "<DATABASE_ID>",
@@ -1744,6 +1924,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createRow(
             "<DATABASE_ID>",
@@ -1775,6 +1958,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->createRows(
             "<DATABASE_ID>",
@@ -1805,6 +1991,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->upsertRows(
             "<DATABASE_ID>",
@@ -1835,6 +2024,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateRows(
             "<DATABASE_ID>",
@@ -1864,6 +2056,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteRows(
             "<DATABASE_ID>",
@@ -1888,6 +2083,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->getRow(
             "<DATABASE_ID>",
@@ -1913,6 +2111,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->upsertRow(
             "<DATABASE_ID>",
@@ -1938,6 +2139,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->updateRow(
             "<DATABASE_ID>",
@@ -1955,6 +2159,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->deleteRow(
             "<DATABASE_ID>",
@@ -1980,6 +2187,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->decrementRowColumn(
             "<DATABASE_ID>",
@@ -2006,6 +2216,9 @@ final class TablesDBTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tablesDB->incrementRowColumn(
             "<DATABASE_ID>",

--- a/tests/Appwrite/Services/TeamsTest.php
+++ b/tests/Appwrite/Services/TeamsTest.php
@@ -37,6 +37,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->list();
 
@@ -57,6 +60,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->create(
             "<TEAM_ID>",
@@ -80,6 +86,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->get(
             "<TEAM_ID>"
@@ -102,6 +111,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->updateName(
             "<TEAM_ID>",
@@ -118,6 +130,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->delete(
             "<TEAM_ID>"
@@ -153,6 +168,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->listMemberships(
             "<TEAM_ID>"
@@ -183,6 +201,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->createMembership(
             "<TEAM_ID>",
@@ -214,6 +235,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->getMembership(
             "<TEAM_ID>",
@@ -245,6 +269,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->updateMembership(
             "<TEAM_ID>",
@@ -262,6 +289,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->deleteMembership(
             "<TEAM_ID>",
@@ -293,6 +323,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->updateMembershipStatus(
             "<TEAM_ID>",
@@ -311,6 +344,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->getPrefs(
             "<TEAM_ID>"
@@ -326,6 +362,9 @@ final class TeamsTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->teams->updatePrefs(
             "<TEAM_ID>",

--- a/tests/Appwrite/Services/TokensTest.php
+++ b/tests/Appwrite/Services/TokensTest.php
@@ -38,6 +38,9 @@ final class TokensTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tokens->list(
             "<BUCKET_ID>",
@@ -62,6 +65,9 @@ final class TokensTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tokens->createFileToken(
             "<BUCKET_ID>",
@@ -86,6 +92,9 @@ final class TokensTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tokens->get(
             "<TOKEN_ID>"
@@ -109,6 +118,9 @@ final class TokensTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tokens->update(
             "<TOKEN_ID>"
@@ -124,6 +136,9 @@ final class TokensTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->tokens->delete(
             "<TOKEN_ID>"

--- a/tests/Appwrite/Services/UsageTest.php
+++ b/tests/Appwrite/Services/UsageTest.php
@@ -41,6 +41,9 @@ final class UsageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->usage->listEvents();
 
@@ -65,6 +68,9 @@ final class UsageTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->usage->listGauges();
 

--- a/tests/Appwrite/Services/UsersTest.php
+++ b/tests/Appwrite/Services/UsersTest.php
@@ -61,6 +61,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->list();
 
@@ -102,6 +105,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->create(
             "<USER_ID>"
@@ -145,6 +151,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createArgon2User(
             "<USER_ID>",
@@ -190,6 +199,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createBcryptUser(
             "<USER_ID>",
@@ -223,6 +235,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listIdentities();
 
@@ -236,6 +251,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->deleteIdentity(
             "<IDENTITY_ID>"
@@ -279,6 +297,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createMD5User(
             "<USER_ID>",
@@ -324,6 +345,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createPHPassUser(
             "<USER_ID>",
@@ -369,6 +393,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createScryptUser(
             "<USER_ID>",
@@ -419,6 +446,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createScryptModifiedUser(
             "<USER_ID>",
@@ -467,6 +497,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createSHAUser(
             "<USER_ID>",
@@ -512,6 +545,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->get(
             "<USER_ID>"
@@ -527,6 +563,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->delete(
             "<USER_ID>"
@@ -570,6 +609,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateEmail(
             "<USER_ID>",
@@ -614,6 +656,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateImpersonator(
             "<USER_ID>",
@@ -632,6 +677,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createJWT(
             "<USER_ID>"
@@ -675,6 +723,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateLabels(
             "<USER_ID>",
@@ -719,6 +770,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listLogs(
             "<USER_ID>"
@@ -754,6 +808,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listMemberships(
             "<USER_ID>"
@@ -797,6 +854,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateMFA(
             "<USER_ID>",
@@ -813,6 +873,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->deleteMFAAuthenticator(
             "<USER_ID>",
@@ -834,6 +897,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listMFAFactors(
             "<USER_ID>"
@@ -851,6 +917,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->getMFARecoveryCodes(
             "<USER_ID>"
@@ -868,6 +937,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateMFARecoveryCodes(
             "<USER_ID>"
@@ -885,6 +957,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createMFARecoveryCodes(
             "<USER_ID>"
@@ -928,6 +1003,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateName(
             "<USER_ID>",
@@ -972,6 +1050,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updatePassword(
             "<USER_ID>",
@@ -1016,6 +1097,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updatePhone(
             "<USER_ID>",
@@ -1032,6 +1116,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->getPrefs(
             "<USER_ID>"
@@ -1047,6 +1134,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updatePrefs(
             "<USER_ID>",
@@ -1098,6 +1188,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listSessions(
             "<USER_ID>"
@@ -1143,6 +1236,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createSession(
             "<USER_ID>"
@@ -1158,6 +1254,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->deleteSessions(
             "<USER_ID>"
@@ -1173,6 +1272,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->deleteSession(
             "<USER_ID>",
@@ -1217,6 +1319,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateStatus(
             "<USER_ID>",
@@ -1247,6 +1352,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->listTargets(
             "<USER_ID>"
@@ -1271,6 +1379,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createTarget(
             "<USER_ID>",
@@ -1298,6 +1409,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->getTarget(
             "<USER_ID>",
@@ -1323,6 +1437,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateTarget(
             "<USER_ID>",
@@ -1339,6 +1456,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->deleteTarget(
             "<USER_ID>",
@@ -1362,6 +1482,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->createToken(
             "<USER_ID>"
@@ -1405,6 +1528,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updateEmailVerification(
             "<USER_ID>",
@@ -1449,6 +1575,9 @@ final class UsersTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->users->updatePhoneVerification(
             "<USER_ID>",

--- a/tests/Appwrite/Services/WebhooksTest.php
+++ b/tests/Appwrite/Services/WebhooksTest.php
@@ -44,6 +44,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->list();
 
@@ -71,6 +74,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->create(
             "<WEBHOOK_ID>",
@@ -103,6 +109,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->get(
             "<WEBHOOK_ID>"
@@ -132,6 +141,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->update(
             "<WEBHOOK_ID>",
@@ -150,6 +162,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->delete(
             "<WEBHOOK_ID>"
@@ -179,6 +194,9 @@ final class WebhooksTest extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any())
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
         $response = $this->webhooks->updateSecret(
             "<WEBHOOK_ID>"


### PR DESCRIPTION
This PR contains updates to the PHP SDK for version 25.1.0.

## What's Changed

* Added: `createSesProvider` and `updateSesProvider` to `messaging`
* Added: `updateOAuth2Server` to `project` for OAuth2 server settings
* Added: `updatePasswordStrengthPolicy` and `PolicyPasswordStrength` to `project`
* Added: `getAuditsDB` health check to `health`
* Added: `password-strength` to `ProjectPolicyId`
* Added: `apps.read` and `apps.write` to `ProjectKeyScopes`